### PR TITLE
Keep delivery_handle until callback touches it

### DIFF
--- a/lib/rdkafka/bindings.rb
+++ b/lib/rdkafka/bindings.rb
@@ -154,11 +154,12 @@ module Rdkafka
       :void, [:pointer, :pointer, :pointer]
     ) do |client_ptr, message_ptr, opaque_ptr|
       message = Message.new(message_ptr)
-      delivery_handle = Rdkafka::Producer::DeliveryHandle.new(message[:_private])
-      delivery_handle[:pending] = false
-      delivery_handle[:response] = message[:err]
-      delivery_handle[:partition] = message[:partition]
-      delivery_handle[:offset] = message[:offset]
+      if delivery_handle = Rdkafka::Producer::DeliveryHandle.remove(message[:_private])
+        delivery_handle[:pending] = false
+        delivery_handle[:response] = message[:err]
+        delivery_handle[:partition] = message[:partition]
+        delivery_handle[:offset] = message[:offset]
+      end
     end
   end
 end

--- a/lib/rdkafka/producer.rb
+++ b/lib/rdkafka/producer.rb
@@ -69,6 +69,7 @@ module Rdkafka
       delivery_handle[:response] = -1
       delivery_handle[:partition] = -1
       delivery_handle[:offset] = -1
+      DeliveryHandle.register(delivery_handle)
 
       # Produce the message
       response = Rdkafka::Bindings.rd_kafka_producev(
@@ -85,6 +86,7 @@ module Rdkafka
 
       # Raise error if the produce call was not successfull
       if response != 0
+        DeliveryHandle.remove(delivery_handle.to_ptr.address)
         raise RdkafkaError.new(response)
       end
 

--- a/lib/rdkafka/producer/delivery_handle.rb
+++ b/lib/rdkafka/producer/delivery_handle.rb
@@ -8,6 +8,16 @@ module Rdkafka
              :partition, :int,
              :offset, :int64
 
+      REGISTRY = {}
+
+      def self.register(handle)
+        REGISTRY[handle.to_ptr.address] = handle
+      end
+
+      def self.remove(addr)
+        REGISTRY.delete(addr)
+      end
+
       # Whether the delivery handle is still pending.
       #
       # @return [Boolean]


### PR DESCRIPTION
delivery_handle need to be kept allocated from Producer#produce to
DeliveryCallback. But since FFI::Struct enables autorelease by default,
it may be released before DeliveryCallback. This causes
DeliveryCallback to write already freed (and maybe used by someone
others) area. It means a memory corruption and it will cause SEGV.

This keeps a reference for the handler to prevent GC.

fix https://github.com/appsignal/rdkafka-ruby/issues/15