### PR TITLE
Implement TopicPartitionList in Ruby

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -16,7 +16,7 @@ rvm:
 
 before_install:
   - gem update --system
-  - wget http://www.us.apache.org/dist/kafka/1.0.0/kafka_2.12-1.0.0.tgz -O kafka.tgz
+  - wget "https://www-eu.apache.org/dyn/mirrors/mirrors.cgi?action=download&filename=kafka/1.0.2/kafka_2.12-1.0.2.tgz" -O kafka.tgz
   - mkdir -p kafka && tar xzf kafka.tgz -C kafka --strip-components 1
   - nohup bash -c "cd kafka && bin/zookeeper-server-start.sh config/zookeeper.properties &"
   - nohup bash -c "cd kafka && bin/kafka-server-start.sh config/server.properties &"

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,6 +2,9 @@ language: ruby
 
 sudo: false
 
+services:
+  - docker
+
 env:
   global:
     - CC_TEST_REPORTER_ID=9f7f740ac1b6e264e1189fa07a6687a87bcdb9f3c0f4199d4344ab3b538e187e
@@ -16,14 +19,10 @@ rvm:
 
 before_install:
   - gem update --system
-  - wget "https://www-eu.apache.org/dyn/mirrors/mirrors.cgi?action=download&filename=kafka/1.0.2/kafka_2.12-1.0.2.tgz" -O kafka.tgz
-  - mkdir -p kafka && tar xzf kafka.tgz -C kafka --strip-components 1
-  - nohup bash -c "cd kafka && bin/zookeeper-server-start.sh config/zookeeper.properties &"
-  - nohup bash -c "cd kafka && bin/kafka-server-start.sh config/server.properties &"
 
 before_script:
+  - docker-compose up -d
   - cd ext && bundle exec rake && cd ..
-  - bundle exec rake create_topics
   - curl -L https://codeclimate.com/downloads/test-reporter/test-reporter-latest-linux-amd64 > ./cc-test-reporter
   - chmod +x ./cc-test-reporter
   - ./cc-test-reporter before-build
@@ -32,7 +31,5 @@ script:
   - bundle exec rspec
 
 after_script:
-  - echo "Posting coverage to codeclimate"
+  - docker-compose stop
   - ./cc-test-reporter after-build --exit-code $TRAVIS_TEST_RESULT
-  - echo "Killing all java processes"
-  - killall -9 java

--- a/README.md
+++ b/README.md
@@ -77,9 +77,15 @@ collected. See https://github.com/appsignal/rdkafka-ruby/issues/19
 
 ## Development
 
-For development we expect a local zookeeper and kafka instance to be
-running. Run `bundle` and `cd ext && bundle exec rake && cd ..`. Then
-create the topics as expected in the specs: `bundle exec rake create_topics`.
+A Docker Compose file is included to run Kafka and Zookeeper. To run
+that:
+
+```
+docker-compose up
+```
+
+Run `bundle` and `cd ext && bundle exec rake && cd ..` to download and
+compile `librdkafka`.
 
 You can then run `bundle exec rspec` to run the tests. To see rdkafka
 debug output:
@@ -88,6 +94,15 @@ debug output:
 DEBUG_PRODUCER=true bundle exec rspec
 DEBUG_CONSUMER=true bundle exec rspec
 ```
+
+After running the tests you can bring the cluster down to start with a
+clean slate:
+
+```
+docker-compose down
+```
+
+## Example
 
 To see everything working run these in separate tabs:
 

--- a/Rakefile
+++ b/Rakefile
@@ -1,19 +1,5 @@
 require "./lib/rdkafka"
 
-task :create_topics do
-  puts "Creating test topics"
-  kafka_topics = if ENV['TRAVIS']
-                   'kafka/bin/kafka-topics.sh'
-                 else
-                   'kafka-topics'
-                 end
-  `#{kafka_topics} --create --topic=consume_test_topic --zookeeper=127.0.0.1:2181 --partitions=3 --replication-factor=1`
-  `#{kafka_topics} --create --topic=empty_test_topic --zookeeper=127.0.0.1:2181 --partitions=3 --replication-factor=1`
-  `#{kafka_topics} --create --topic=load_test_topic --zookeeper=127.0.0.1:2181 --partitions=3 --replication-factor=1`
-  `#{kafka_topics} --create --topic=produce_test_topic --zookeeper=127.0.0.1:2181 --partitions=3 --replication-factor=1`
-  `#{kafka_topics} --create --topic=rake_test_topic --zookeeper=127.0.0.1:2181 --partitions=3 --replication-factor=1`
-end
-
 task :produce_messages do
   config = {:"bootstrap.servers" => "localhost:9092"}
   if ENV["DEBUG"]

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,18 @@
+version: '2'
+services:
+  zookeeper:
+    image: wurstmeister/zookeeper
+    ports:
+      - "2181:2181"
+  kafka:
+    image: wurstmeister/kafka:1.0.1
+    ports:
+      - "9092:9092"
+    environment:
+      KAFKA_ADVERTISED_HOST_NAME: localhost
+      KAFKA_ADVERTISED_PORT: 9092
+      KAFKA_ZOOKEEPER_CONNECT: zookeeper:2181
+      KAFKA_AUTO_CREATE_TOPICS_ENABLE: 'false'
+      KAFKA_CREATE_TOPICS: "consume_test_topic:3:1,empty_test_topic:3:1,load_test_topic:3:1,produce_test_topic:3:1,rake_test_topic:3:1"
+    volumes:
+      - /var/run/docker.sock:/var/run/docker.sock

--- a/lib/rdkafka/consumer/partition.rb
+++ b/lib/rdkafka/consumer/partition.rb
@@ -7,7 +7,7 @@ module Rdkafka
       attr_reader :partition
 
       # Partition's offset
-      # @return [Integer]
+      # @return [Integer, nil]
       attr_reader :offset
 
       # @private
@@ -19,7 +19,11 @@ module Rdkafka
       # Human readable representation of this partition.
       # @return [String]
       def to_s
-        "<Partition #{partition} with offset #{offset}>"
+        if offset.nil?
+          "<Partition #{partition} without offset>"
+        else
+          "<Partition #{partition} with offset #{offset}>"
+        end
       end
 
       # Human readable representation of this partition.

--- a/spec/rdkafka/consumer/partition_spec.rb
+++ b/spec/rdkafka/consumer/partition_spec.rb
@@ -1,7 +1,8 @@
 require "spec_helper"
 
 describe Rdkafka::Consumer::Partition do
-  subject { Rdkafka::Consumer::Partition.new(1, 100) }
+  let(:offset) { 100 }
+  subject { Rdkafka::Consumer::Partition.new(1, offset) }
 
   it "should have a partition" do
     expect(subject.partition).to eq 1
@@ -20,6 +21,14 @@ describe Rdkafka::Consumer::Partition do
   describe "#inspect" do
     it "should return a human readable representation" do
       expect(subject.to_s).to eq "<Partition 1 with offset 100>"
+    end
+
+    context "without offset" do
+      let(:offset) { nil }
+
+      it "should return a human readable representation" do
+        expect(subject.to_s).to eq "<Partition 1 without offset>"
+      end
     end
   end
 

--- a/spec/rdkafka/consumer_spec.rb
+++ b/spec/rdkafka/consumer_spec.rb
@@ -189,8 +189,8 @@ describe Rdkafka::Consumer do
       partitions = consumer.committed.to_h["consume_test_topic"]
       expect(partitions).not_to be_nil
       expect(partitions[0].offset).to be > 0
-      expect(partitions[1].offset).to eq -1001
-      expect(partitions[2].offset).to eq -1001
+      expect(partitions[1].offset).to be nil
+      expect(partitions[2].offset).to be nil
     end
 
     it "should fetch the committed offsets for a specified topic partition list" do
@@ -200,8 +200,8 @@ describe Rdkafka::Consumer do
       partitions = consumer.committed(list).to_h["consume_test_topic"]
       expect(partitions).not_to be_nil
       expect(partitions[0].offset).to be > 0
-      expect(partitions[1].offset).to eq -1001
-      expect(partitions[2].offset).to eq -1001
+      expect(partitions[1].offset).to be nil
+      expect(partitions[2].offset).to be nil
     end
 
     it "should raise an error when getting committed fails" do


### PR DESCRIPTION
It turned out to be to hard to keep pointers to native topic partitions lists around. Therefore we now create and copy them on the fly.

Fixes #33 