### PR TITLE
store_offset: pass actual message in tests.

### DIFF
--- a/spec/rdkafka/consumer_spec.rb
+++ b/spec/rdkafka/consumer_spec.rb
@@ -123,13 +123,11 @@ describe Rdkafka::Consumer do
       ).wait
     end
 
-    # Wait for message commits the current state,
-    # commit is therefore tested here.
-    let!(:message) do
+    let(:message) do
       wait_for_message(
         topic: "consume_test_topic",
         delivery_report: report,
-        config: config
+        consumer: consumer
       )
     end
 
@@ -234,11 +232,6 @@ describe Rdkafka::Consumer do
         end
 
         it "should store the offset for a message" do
-          message = double(
-            :topic => 'consume_test_topic',
-            :partition => 1,
-            :offset => 5
-          )
           consumer.store_offset(message)
           consumer.commit
 
@@ -247,7 +240,7 @@ describe Rdkafka::Consumer do
           end
           partitions = consumer.committed(list).to_h["consume_test_topic"]
           expect(partitions).not_to be_nil
-          expect(partitions[1].offset).to eq 6
+          expect(partitions[message.partition].offset).to eq(message.offset + 1)
         end
 
         it "should raise an error with invalid input" do

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -38,9 +38,8 @@ def new_native_topic(topic_name="topic_name")
   )
 end
 
-def wait_for_message(topic:, delivery_report:, timeout_in_seconds: 30, config: nil)
-  config = rdkafka_config if config.nil?
-  consumer = config.consumer
+def wait_for_message(topic:, delivery_report:, timeout_in_seconds: 30, consumer: nil)
+  consumer = rdkafka_config.consumer if consumer.nil?
   consumer.subscribe(topic)
   timeout = Time.now.to_i + timeout_in_seconds
   loop do


### PR DESCRIPTION
Pass an actual message to `Consumer#store_offset` in the test. Otherwise
we might try to commit an offset for partition that our consumer isn't
subscribed to.

This changes `wait_for_message` to accept a `consumer`, so that we can
receive and `#store_offset` from the same consumer.