### PR TITLE
Document list param of commit method

### DIFF
--- a/lib/rdkafka/consumer.rb
+++ b/lib/rdkafka/consumer.rb
@@ -223,6 +223,7 @@ module Rdkafka
 
     # Commit the current offsets of this consumer
     #
+    # @param list [TopicPartitionList] The topic with partitions to commit
     # @param async [Boolean] Whether to commit async or wait for the commit to finish
     #
     # @raise [RdkafkaError] When comitting fails

--- a/lib/rdkafka/consumer.rb
+++ b/lib/rdkafka/consumer.rb
@@ -223,7 +223,7 @@ module Rdkafka
 
     # Commit the current offsets of this consumer
     #
-    # @param list [TopicPartitionList] The topic with partitions to commit
+    # @param list [TopicPartitionList,nil] The topic with partitions to commit
     # @param async [Boolean] Whether to commit async or wait for the commit to finish
     #
     # @raise [RdkafkaError] When comitting fails


### PR DESCRIPTION
When I was browsing through the source code I noticed the documentation was missing for the list param of the commit method of a consumer. 