### PR TITLE
Delivery callback for producer

### DIFF
--- a/spec/rdkafka/config_spec.rb
+++ b/spec/rdkafka/config_spec.rb
@@ -27,6 +27,7 @@ describe Rdkafka::Config do
           puts stats
         end
       }.not_to raise_error
+      expect(Rdkafka::Config.statistics_callback).to be_a Proc
     end
 
     it "should not accept a callback that's not a proc" do


### PR DESCRIPTION
Add an optional callback that gets called when a produced message has been delivered.

Fixes #64 