### PR TITLE
Add consumer rebalance listener

### DIFF
--- a/lib/rdkafka/bindings.rb
+++ b/lib/rdkafka/bindings.rb
@@ -149,6 +149,42 @@ module Rdkafka
     attach_function :rd_kafka_consumer_close, [:pointer], :void, blocking: true
     attach_function :rd_kafka_offset_store, [:pointer, :int32, :int64], :int
 
+    # Rebalance
+
+    RD_KAFKA_RESP_ERR__ASSIGN_PARTITIONS = -175
+    RD_KAFKA_RESP_ERR__REVOKE_PARTITIONS = -174
+
+    callback :rebalance_cb_function, [:pointer, :int, :pointer, :pointer], :void
+    attach_function :rd_kafka_conf_set_rebalance_cb, [:pointer, :rebalance_cb_function], :void
+
+    RebalanceCallback = FFI::Function.new(
+      :void, [:pointer, :int, :pointer, :pointer]
+    ) do |client_ptr, code, partitions_ptr, opaque_ptr|
+      case code
+      when RD_KAFKA_RESP_ERR__ASSIGN_PARTITIONS
+        Rdkafka::Bindings.rd_kafka_assign(client_ptr, partitions_ptr)
+      else # RD_KAFKA_RESP_ERR__REVOKE_PARTITIONS or errors
+        Rdkafka::Bindings.rd_kafka_assign(client_ptr, FFI::Pointer::NULL)
+      end
+
+      opaque = Rdkafka::Config.opaques[opaque_ptr.to_i]
+      return unless opaque
+
+      tpl = Rdkafka::Consumer::TopicPartitionList.from_native_tpl(partitions_ptr, false).freeze
+      consumer = Rdkafka::Consumer.new(client_ptr)
+
+      begin
+        case code
+        when RD_KAFKA_RESP_ERR__ASSIGN_PARTITIONS
+          opaque.call_on_partitions_assigned(consumer, tpl)
+        when RD_KAFKA_RESP_ERR__REVOKE_PARTITIONS
+          opaque.call_on_partitions_revoked(consumer, tpl)
+        end
+      rescue Exception => err
+        Rdkafka::Config.logger.error("Unhandled exception: #{err.class} - #{err.message}")
+      end
+    end
+
     # Stats
 
     attach_function :rd_kafka_query_watermark_offsets, [:pointer, :string, :int, :pointer, :pointer, :int], :int

--- a/lib/rdkafka/consumer/topic_partition_list.rb
+++ b/lib/rdkafka/consumer/topic_partition_list.rb
@@ -93,7 +93,7 @@ module Rdkafka
       # @return [TopicPartitionList]
       #
       # @private
-      def self.from_native_tpl(pointer)
+      def self.from_native_tpl(pointer, destroy = true)
         # Data to be moved into the tpl
         data = {}
 
@@ -121,7 +121,9 @@ module Rdkafka
         TopicPartitionList.new(data)
       ensure
         # Destroy the tpl
-        Rdkafka::Bindings.rd_kafka_topic_partition_list_destroy(pointer)
+        if destroy
+          Rdkafka::Bindings.rd_kafka_topic_partition_list_destroy(pointer)
+        end
       end
 
       # Create a native tpl with the contents of this object added

--- a/spec/rdkafka/consumer_spec.rb
+++ b/spec/rdkafka/consumer_spec.rb
@@ -462,7 +462,7 @@ describe Rdkafka::Consumer do
     end
 
     def notify_listener(listener)
-      # 1. sibscribe and poll
+      # 1. subscribe and poll
       config.consumer_rebalance_listener = listener
       consumer.subscribe("consume_test_topic")
       wait_for_assignment(consumer)

--- a/spec/rdkafka/consumer_spec.rb
+++ b/spec/rdkafka/consumer_spec.rb
@@ -468,7 +468,7 @@ describe Rdkafka::Consumer do
       wait_for_assignment(consumer)
       consumer.poll(100)
 
-      # 2. unsibscribe
+      # 2. unsubscribe
       consumer.unsubscribe
       wait_for_unassignment(consumer)
       consumer.close

--- a/spec/rdkafka/consumer_spec.rb
+++ b/spec/rdkafka/consumer_spec.rb
@@ -417,4 +417,61 @@ describe Rdkafka::Consumer do
       end
     end
   end
+
+  describe "a rebalance listener" do
+    it "should get notifications" do
+      listener = Struct.new(:queue) do
+        def on_partitions_assigned(consumer, list)
+          collect(:assign, list)
+        end
+
+        def on_partitions_revoked(consumer, list)
+          collect(:revoke, list)
+        end
+
+        def collect(name, list)
+          partitions = list.to_h.map { |key, values| [key, values.map(&:partition)] }.flatten
+          queue << ([name] + partitions)
+        end
+      end.new([])
+
+      notify_listener(listener)
+
+      expect(listener.queue).to eq([
+        [:assign, "consume_test_topic", 0, 1, 2],
+        [:revoke, "consume_test_topic", 0, 1, 2]
+      ])
+    end
+
+    it 'should handle callback exceptions' do
+      listener = Struct.new(:queue) do
+        def on_partitions_assigned(consumer, list)
+          queue << :assigned
+          raise 'boom'
+        end
+
+        def on_partitions_revoked(consumer, list)
+          queue << :revoked
+          raise 'boom'
+        end
+      end.new([])
+
+      notify_listener(listener)
+
+      expect(listener.queue).to eq([:assigned, :revoked])
+    end
+
+    def notify_listener(listener)
+      # 1. sibscribe and poll
+      config.consumer_rebalance_listener = listener
+      consumer.subscribe("consume_test_topic")
+      wait_for_assignment(consumer)
+      consumer.poll(100)
+
+      # 2. unsibscribe
+      consumer.unsubscribe
+      wait_for_unassignment(consumer)
+      consumer.close
+    end
+  end
 end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -61,3 +61,10 @@ def wait_for_assignment(consumer)
     sleep 1
   end
 end
+
+def wait_for_unassignment(consumer)
+  10.times do
+    break if consumer.assignment.empty?
+    sleep 1
+  end
+end


### PR DESCRIPTION
Provides a way to get notifications on partition assignment/revocation for the subscribed topics

```
class MyRebalanceListener
  def on_partitions_assigned(consumer, partitions)
     log.info("partitions assigned #{partitions}")
  end

  def on_partitions_revoked(consumer, partitions)
     log.info("partitions revoked #{partitions}")
  end
end

params = { ... }
config = Rdkafka::Config.new(params)
config.consumer_rebalance_listener = MyRebalanceListener.new
consumer = config.consumer
```

Fixes #63 