### PR TITLE
Add cluster and memeber information

### DIFF
--- a/lib/rdkafka/bindings.rb
+++ b/lib/rdkafka/bindings.rb
@@ -22,6 +22,11 @@ module Rdkafka
     attach_function :rd_kafka_poll, [:pointer, :int], :void, blocking: true
     attach_function :rd_kafka_outq_len, [:pointer], :int, blocking: true
 
+    # Metadata
+
+    attach_function :rd_kafka_memberid, [:pointer], :string
+    attach_function :rd_kafka_clusterid, [:pointer], :string
+
     # Message struct
 
     class Message < FFI::Struct

--- a/lib/rdkafka/consumer.rb
+++ b/lib/rdkafka/consumer.rb
@@ -190,6 +190,22 @@ module Rdkafka
       out
     end
 
+    # Returns the ClusterId as reported in broker metadata.
+    #
+    # @return [String, nil]
+    def cluster_id
+      Rdkafka::Bindings.rd_kafka_clusterid(@native_kafka)
+    end
+
+    # Returns this client's broker-assigned group member id
+    #
+    # This currently requires the high-level KafkaConsumer
+    #
+    # @return [String, nil]
+    def member_id
+      Rdkafka::Bindings.rd_kafka_memberid(@native_kafka)
+    end
+
     # Store offset of a message to be used in the next commit of this consumer
     #
     # When using this `enable.auto.offset.store` should be set to `false` in the config.

--- a/spec/rdkafka/consumer_spec.rb
+++ b/spec/rdkafka/consumer_spec.rb
@@ -358,6 +358,22 @@ describe Rdkafka::Consumer do
     end
   end
 
+  describe "#cluster_id" do
+    it 'should return the current ClusterId' do
+      consumer.subscribe("consume_test_topic")
+      wait_for_assignment(consumer)
+      expect(consumer.cluster_id).not_to be_empty
+    end
+  end
+
+  describe "#member_id" do
+    it 'should return the current MemberId' do
+      consumer.subscribe("consume_test_topic")
+      wait_for_assignment(consumer)
+      expect(consumer.member_id).to start_with('rdkafka-')
+    end
+  end
+
   describe "#poll" do
     it "should return nil if there is no subscription" do
       expect(consumer.poll(1000)).to be_nil


### PR DESCRIPTION
New bindings for

* `rd_kafka_memberid`
* `rd_kafka_clusterid`

It will be useful for debugging & health checking