### PR TITLE
Fix memory leaks while reading a native TopicPartitionList by reference

### DIFF
--- a/lib/rdkafka/consumer.rb
+++ b/lib/rdkafka/consumer.rb
@@ -67,12 +67,12 @@ module Rdkafka
     # @return [TopicPartitionList]
     def subscription
       tpl = FFI::MemoryPointer.new(:pointer)
-      tpl.autorelease = false
       response = Rdkafka::Bindings.rd_kafka_subscription(@native_kafka, tpl)
       if response != 0
         raise Rdkafka::RdkafkaError.new(response)
       end
-      Rdkafka::Consumer::TopicPartitionList.from_native_tpl(tpl.get_pointer(0))
+      tpl = tpl.read(:pointer).tap { |it| it.autorelease = false }
+      Rdkafka::Consumer::TopicPartitionList.from_native_tpl(tpl)
     end
 
     # Atomic assignment of partitions to consume
@@ -100,12 +100,13 @@ module Rdkafka
     # @return [TopicPartitionList]
     def assignment
       tpl = FFI::MemoryPointer.new(:pointer)
-      tpl.autorelease = false
       response = Rdkafka::Bindings.rd_kafka_assignment(@native_kafka, tpl)
       if response != 0
         raise Rdkafka::RdkafkaError.new(response)
       end
-      Rdkafka::Consumer::TopicPartitionList.from_native_tpl(tpl.get_pointer(0))
+
+      tpl = tpl.read(:pointer).tap { |it| it.autorelease = false  }
+      Rdkafka::Consumer::TopicPartitionList.from_native_tpl(tpl)
     end
 
     # Return the current committed offset per partition for this consumer group.


### PR DESCRIPTION
Methods with leaks:

* Consumer#subscription
* Consumer#assignment

Reading by reference before:

```
tpl = MemoryPointer.new(:pointer)
tpl.autorelease = false # LEAK, a leak here
... read tpl by reference
TopicPartitionList.from_native(tpl.get_pointer(0)) # DOUBLE FREE, Possible double free memory here
```

this code is equivalent of C code
```
  void* tpl = malloc(sizeof(size_t) * 1);
  // read by reference
  // construct from native tpl using `tpl[0]`
  // as result we have a memory leak
```

I wrote a test to ensure that leaks are exists

```
for i 0..1_000_000
   _assignment = consumer.assignment
   if i % 1_000 == 0
      GC.start
      puts `ps -o rss= -p #{$$}`.to_i
   end
end
```

Before patch it starts from ~37_404kb and ends to ~155_652kb
After patch it starts from ~38_056kb and ends to ~44_184kb