### PR TITLE
Fix memory leak for TopicPartitionList#to_native_tpl while calling consumer's pause/resume.

### DIFF
--- a/lib/rdkafka/bindings.rb
+++ b/lib/rdkafka/bindings.rb
@@ -187,7 +187,7 @@ module Rdkafka
       opaque = Rdkafka::Config.opaques[opaque_ptr.to_i]
       return unless opaque
 
-      tpl = Rdkafka::Consumer::TopicPartitionList.from_native_tpl(partitions_ptr, false).freeze
+      tpl = Rdkafka::Consumer::TopicPartitionList.from_native_tpl(partitions_ptr).freeze
       consumer = Rdkafka::Consumer.new(client_ptr)
 
       begin

--- a/lib/rdkafka/consumer/topic_partition_list.rb
+++ b/lib/rdkafka/consumer/topic_partition_list.rb
@@ -88,12 +88,12 @@ module Rdkafka
 
       # Create a new topic partition list based of a native one.
       #
-      # @param pointer [FFI::Pointer] Optional pointer to an existing native list. Its contents will be copied and afterwards it will be destroyed.
+      # @param pointer [FFI::Pointer] Optional pointer to an existing native list. Its contents will be copied.
       #
       # @return [TopicPartitionList]
       #
       # @private
-      def self.from_native_tpl(pointer, destroy = true)
+      def self.from_native_tpl(pointer)
         # Data to be moved into the tpl
         data = {}
 
@@ -119,44 +119,55 @@ module Rdkafka
 
         # Return the created object
         TopicPartitionList.new(data)
-      ensure
-        # Destroy the tpl
-        if destroy
-          Rdkafka::Bindings.rd_kafka_topic_partition_list_destroy(pointer)
-        end
       end
 
-      # Create a native tpl with the contents of this object added
+      # Create a native tpl with the contents of this object added.
       #
+      # The pointer will be cleaned by `rd_kafka_topic_partition_list_destroy` when GC releases it.
+      #
+      # @return [FFI::AutoPointer]
       # @private
       def to_native_tpl
-        Rdkafka::Bindings.rd_kafka_topic_partition_list_new(count).tap do |tpl|
-          @data.each do |topic, partitions|
-            if partitions
-              partitions.each do |p|
-                Rdkafka::Bindings.rd_kafka_topic_partition_list_add(
-                  tpl,
-                  topic,
-                  p.partition
-                )
-                if p.offset
-                  Rdkafka::Bindings.rd_kafka_topic_partition_list_set_offset(
-                    tpl,
-                    topic,
-                    p.partition,
-                    p.offset
-                  )
-                end
-              end
-            else
+        tpl = TopicPartitionList.new_native_tpl(count)
+
+        @data.each do |topic, partitions|
+          if partitions
+            partitions.each do |p|
               Rdkafka::Bindings.rd_kafka_topic_partition_list_add(
                 tpl,
                 topic,
-                -1
+                p.partition
               )
+              if p.offset
+                Rdkafka::Bindings.rd_kafka_topic_partition_list_set_offset(
+                  tpl,
+                  topic,
+                  p.partition,
+                  p.offset
+                )
+              end
             end
+          else
+            Rdkafka::Bindings.rd_kafka_topic_partition_list_add(
+              tpl,
+              topic,
+              -1
+            )
           end
         end
+
+        tpl
+      end
+
+      # Creates a new native tpl and wraps it into FFI::AutoPointer which in turn calls
+      # `rd_kafka_topic_partition_list_destroy` when a pointer will be cleaned by GC
+      #
+      # @param count [Integer] an initial capacity of partitions list
+      # @return [FFI::AutoPointer]
+      # @private
+      def self.new_native_tpl(count)
+        tpl = Rdkafka::Bindings.rd_kafka_topic_partition_list_new(count)
+        FFI::AutoPointer.new(tpl, Rdkafka::Bindings.method(:rd_kafka_topic_partition_list_destroy))
       end
     end
   end


### PR DESCRIPTION
* `TopicPartitionList#to_native_tpl` returns a `FFI::AutoPointer` which will be cleaned by `rd_kafka_topic_partition_list_destroy`
* doesn't release pointer in `TopicPartitoinList#from_native_tpl`, releasing must be at the same level as pointer allocation.
