### PR TITLE
add offset related constants / magic numbers

### DIFF
--- a/lib/rdkafka/bindings.rb
+++ b/lib/rdkafka/bindings.rb
@@ -22,6 +22,11 @@ module Rdkafka
     RD_KAFKA_RESP_ERR__NOENT = -156
     RD_KAFKA_RESP_ERR_NO_ERROR = 0
 
+    RD_KAFKA_OFFSET_END       = -1
+    RD_KAFKA_OFFSET_BEGINNING = -2
+    RD_KAFKA_OFFSET_STORED    = -1000
+    RD_KAFKA_OFFSET_INVALID   = -1001
+
     class SizePtr < FFI::Struct
       layout :value, :size_t
     end

--- a/lib/rdkafka/consumer/topic_partition_list.rb
+++ b/lib/rdkafka/consumer/topic_partition_list.rb
@@ -106,7 +106,7 @@ module Rdkafka
             data[elem[:topic]] = nil
           else
             partitions = data[elem[:topic]] || []
-            offset = if elem[:offset] == -1001
+            offset = if elem[:offset] == Rdkafka::Bindings::RD_KAFKA_OFFSET_INVALID
                        nil
                      else
                        elem[:offset]


### PR DESCRIPTION
from https://github.com/edenhill/librdkafka/blob/master/src/rdkafka.h#L3003-L3009

I intentionally omitted `RD_KAFKA_OFFSET_TAIL(CNT)` because it doesn't work with Ruby's constants. Closest I can think of would be:

```ruby
RD_KAFKA_OFFSET_TAIL_BASE = -2000
private_constant :RD_KAFKA_OFFSET_TAIL_BASE
def self.RD_KAFKA_OFFSET_TAIL(cnt); RD_KAFKA_OFFSET_TAIL_BASE - cnt; end
```
but then one ends up with:
```
Rdkafka::Bindings::RD_KAFKA_OFFSET_INVALID
                 ↕ vs
Rdkafka::Bindings.RD_KAFKA_OFFSET_TAIL(some_offset)
```
which is not that nice.

The variables are defined in the "simple consumer" part which is marked as legacy, but they're also used for the high level one (e.g. `rd_kafka_seek` https://github.com/edenhill/librdkafka/blob/master/src/rdkafka.h#L3096-L3111 refer to "logical offsets"). Incidentally, this is also where I'd like to use them :).