### PR TITLE
use queue as log callback to avoid unsafe calls from trap context

### DIFF
--- a/lib/rdkafka/bindings.rb
+++ b/lib/rdkafka/bindings.rb
@@ -130,7 +130,7 @@ module Rdkafka
                  else
                    Logger::UNKNOWN
                  end
-      Rdkafka::Config.logQueue << [severity, "rdkafka: #{line}"]
+      Rdkafka::Config.log_queue << [severity, "rdkafka: #{line}"]
     end
 
     StatsCallback = FFI::Function.new(

--- a/lib/rdkafka/bindings.rb
+++ b/lib/rdkafka/bindings.rb
@@ -130,7 +130,7 @@ module Rdkafka
                  else
                    Logger::UNKNOWN
                  end
-      Rdkafka::Config.logger.add(severity) { "rdkafka: #{line}" }
+      Rdkafka::Config.logQueue << [severity, "rdkafka: #{line}"]
     end
 
     StatsCallback = FFI::Function.new(

--- a/lib/rdkafka/config.rb
+++ b/lib/rdkafka/config.rb
@@ -11,12 +11,30 @@ module Rdkafka
     @@statistics_callback = nil
     # @private
     @@opaques = {}
+    # @private
+    @@log_queue = Queue.new
+
+    Thread.start do
+      loop do
+        severity, msg = @@log_queue.pop
+        @@logger.add(severity, msg)
+      end
+    end
 
     # Returns the current logger, by default this is a logger to stdout.
     #
     # @return [Logger]
     def self.logger
       @@logger
+    end
+
+    # Returns a queue whose contents will be passed to the configured logger. Each entry
+    # should follow the format [Logger::Severity, String]. The benefit over calling the
+    # logger directly is that this is safe to use from trap contexts.
+    #
+    # @return [Queue]
+    def self.logQueue
+      @@log_queue
     end
 
     # Set the logger that will be used for all logging output by this library.

--- a/lib/rdkafka/config.rb
+++ b/lib/rdkafka/config.rb
@@ -33,7 +33,7 @@ module Rdkafka
     # logger directly is that this is safe to use from trap contexts.
     #
     # @return [Queue]
-    def self.logQueue
+    def self.log_queue
       @@log_queue
     end
 

--- a/spec/rdkafka/bindings_spec.rb
+++ b/spec/rdkafka/bindings_spec.rb
@@ -25,39 +25,39 @@ describe Rdkafka::Bindings do
   end
 
   describe "log callback" do
-    let(:log) { StringIO.new }
+    let(:log_queue) { Rdkafka::Config.log_queue }
     before do
-      Rdkafka::Config.logger = Logger.new(log)
+      allow(log_queue).to receive(:<<)
     end
 
     it "should log fatal messages" do
       Rdkafka::Bindings::LogCallback.call(nil, 0, nil, "log line")
-      expect(log.string).to include "FATAL -- : rdkafka: log line"
+      expect(log_queue).to have_received(:<<).with([Logger::FATAL, "rdkafka: log line"])
     end
 
     it "should log error messages" do
       Rdkafka::Bindings::LogCallback.call(nil, 3, nil, "log line")
-      expect(log.string).to include "ERROR -- : rdkafka: log line"
+      expect(log_queue).to have_received(:<<).with([Logger::ERROR, "rdkafka: log line"])
     end
 
     it "should log warning messages" do
       Rdkafka::Bindings::LogCallback.call(nil, 4, nil, "log line")
-      expect(log.string).to include "WARN -- : rdkafka: log line"
+      expect(log_queue).to have_received(:<<).with([Logger::WARN, "rdkafka: log line"])
     end
 
     it "should log info messages" do
       Rdkafka::Bindings::LogCallback.call(nil, 5, nil, "log line")
-      expect(log.string).to include "INFO -- : rdkafka: log line"
+      expect(log_queue).to have_received(:<<).with([Logger::INFO, "rdkafka: log line"])
     end
 
     it "should log debug messages" do
       Rdkafka::Bindings::LogCallback.call(nil, 7, nil, "log line")
-      expect(log.string).to include "DEBUG -- : rdkafka: log line"
+      expect(log_queue).to have_received(:<<).with([Logger::DEBUG, "rdkafka: log line"])
     end
 
     it "should log unknown messages" do
       Rdkafka::Bindings::LogCallback.call(nil, 100, nil, "log line")
-      expect(log.string).to include "ANY -- : rdkafka: log line"
+      expect(log_queue).to have_received(:<<).with([Logger::UNKNOWN, "rdkafka: log line"])
     end
   end
 

--- a/spec/rdkafka/config_spec.rb
+++ b/spec/rdkafka/config_spec.rb
@@ -18,6 +18,17 @@ describe Rdkafka::Config do
         Rdkafka::Config.logger = nil
       }.to raise_error(Rdkafka::Config::NoLoggerError)
     end
+
+    it "supports logging queue" do
+      output = StringIO.new
+      logger = Logger.new(output)
+      Rdkafka::Config.logger = logger
+
+      Rdkafka::Config.logQueue << [Logger::FATAL, "I love testing"]
+      sleep 0.1
+
+      expect(output.string).to include "FATAL -- : I love testing"
+    end
   end
 
   context "statistics callback" do

--- a/spec/rdkafka/config_spec.rb
+++ b/spec/rdkafka/config_spec.rb
@@ -20,14 +20,16 @@ describe Rdkafka::Config do
     end
 
     it "supports logging queue" do
-      output = StringIO.new
-      logger = Logger.new(output)
-      Rdkafka::Config.logger = logger
+      log = StringIO.new
+      Rdkafka::Config.logger = Logger.new(log)
 
       Rdkafka::Config.log_queue << [Logger::FATAL, "I love testing"]
-      sleep 0.1
+      20.times do
+        break if log.string != ""
+        sleep 0.05
+      end
 
-      expect(output.string).to include "FATAL -- : I love testing"
+      expect(log.string).to include "FATAL -- : I love testing"
     end
   end
 

--- a/spec/rdkafka/config_spec.rb
+++ b/spec/rdkafka/config_spec.rb
@@ -24,7 +24,7 @@ describe Rdkafka::Config do
       logger = Logger.new(output)
       Rdkafka::Config.logger = logger
 
-      Rdkafka::Config.logQueue << [Logger::FATAL, "I love testing"]
+      Rdkafka::Config.log_queue << [Logger::FATAL, "I love testing"]
       sleep 0.1
 
       expect(output.string).to include "FATAL -- : I love testing"


### PR DESCRIPTION
The LogCallback is sometimes also triggered from trap contexts. Trap
may only run a subset of Ruby to avoid deadlocks. However, mutex
locks are not safe (see [1]) and the standard logger uses a mutex
to prevent logs from interleaving [2]. In this scenario it would
print "log writing failed.  can't be called from trap context"
(via [3], [4]) on stderr, but omit the actual error message.

This patch introduces a queue which is safe to call from traps for
(see [5]) and spawns a separate thread to empty/print this queue.

[1] https://bugs.ruby-lang.org/issues/7917#note-1
[2] https://github.com/ruby/ruby/blob/3816622fbedd034d338fcb1bbdc80d163e302ae6/lib/logger/log_device.rb#L31
[3] https://github.com/ruby/ruby/blob/3816622fbedd034d338fcb1bbdc80d163e302ae6/lib/logger/log_device.rb#L46
[4] https://github.com/ruby/ruby/blob/3816622fbedd034d338fcb1bbdc80d163e302ae6/thread_sync.c#L246
[5] https://bugs.ruby-lang.org/issues/14222#note-3