### PR TITLE
Refer CPPFLAGS and LDFLAGS when provided on macOS

### DIFF
--- a/ext/Rakefile
+++ b/ext/Rakefile
@@ -23,9 +23,10 @@ task :default => :clean do
   recipe = MiniPortile.new("librdkafka", Rdkafka::LIBRDKAFKA_VERSION)
 
   # Use default homebrew openssl if we're on mac and the directory exists
+  # and each of flags is not empty
   if recipe.host.include?("darwin") && Dir.exists?("/usr/local/opt/openssl")
-    ENV["CPPFLAGS"] = "-I/usr/local/opt/openssl/include"
-    ENV["LDFLAGS"] = "-L/usr/local/opt/openssl/lib"
+    ENV["CPPFLAGS"] = "-I/usr/local/opt/openssl/include" unless ENV["CPPFLAGS"]
+    ENV["LDFLAGS"] = "-L/usr/local/opt/openssl/lib" unless ENV["LDFLAGS"]
   end
 
   recipe.files << {


### PR DESCRIPTION
Our package system uses their bundled libraries as usual.

```log
      [Builder: td-agent] I | 2019-12-20T16:52:48+09:00 | Environment:
      [Builder: td-agent] I | 2019-12-20T16:52:48+09:00 |   CFLAGS="-I/opt/td-agent/embedded/include -O2"
      [Builder: td-agent] I | 2019-12-20T16:52:48+09:00 |   CPPFLAGS="-I/opt/td-agent/embedded/include -O2"
      [Builder: td-agent] I | 2019-12-20T16:52:48+09:00 |   CXXFLAGS="-I/opt/td-agent/embedded/include -O2"
      [Builder: td-agent] I | 2019-12-20T16:52:48+09:00 |   LDFLAGS="-Wl,-rpath,/opt/td-agent/embedded/lib -L/opt/td-agent/embedded/lib"
      [Builder: td-agent] I | 2019-12-20T16:52:48+09:00 |   LD_RUN_PATH="/opt/td-agent/embedded/lib"
      [Builder: td-agent] I | 2019-12-20T16:52:48+09:00 |   OMNIBUS_INSTALL_DIR="/opt/td-agent"
      [Builder: td-agent] I | 2019-12-20T16:52:48+09:00 |   PATH="/opt/td-agent/bin:/opt/td-agent/embedded/bin:/Users/cosmo/GitHub/omnibus-td-agent/vendor/bundle/ruby/2.6.0/bin:/Users/cosmo/.rbenv/versions/2.6.3/bin:/Users/cosmo/.rbenv/libexec:/Users/cosmo/.rbenv/plugins/ruby-build/bin:/Users/cosmo/.rbenv/shims:/Users/cosmo/.rbenv/bin:/usr/bin:/bin:/usr/sbin:/sbin"
      [Builder: td-agent] I | 2019-12-20T16:52:48+09:00 |   PKG_CONFIG_PATH="/opt/td-agent/embedded/lib/pkgconfig"
      [Builder: td-agent] I | 2019-12-20T16:52:48+09:00 | $ /opt/td-agent/embedded/bin/gem install --no-document /Users/cosmo/GitHub/omnibus-td-agent/plugin_gems/16-rdkafka-0.7.0.gem
```

But, rdkafka-ruby is forcibly to set up CPPFLAGS and LDFLAGS.
This commit privents to override forcibly against CPPFLAGS and LDFLAGS.

Otherwise, built librdkafka.dylib refers Homebrew's OpenSSL libraries:

```log
% otool -L /opt/td-agent//embedded/lib/ruby/gems/2.4.0/gems/rdkafka-0.7.0/ext/librdkafka.dylib
/opt/td-agent//embedded/lib/ruby/gems/2.4.0/gems/rdkafka-0.7.0/ext/librdkafka.dylib:
	/opt/td-agent/embedded/lib/ruby/gems/2.4.0/gems/rdkafka-0.7.0/ext/ports/x86_64-apple-darwin19.0.0/librdkafka/1.2.0/lib/librdkafka.1.dylib (compatibility version 0.0.0, current version 0.0.0)
	/usr/local/opt/lz4/lib/liblz4.1.dylib (compatibility version 1.0.0, current version 1.9.2)
	/usr/lib/libSystem.B.dylib (compatibility version 1.0.0, current version 1281.0.0)
	/usr/local/opt/zstd/lib/libzstd.1.dylib (compatibility version 1.0.0, current version 1.4.3)
	/usr/lib/libsasl2.2.dylib (compatibility version 3.0.0, current version 3.15.0)
	/usr/local/opt/openssl/lib/libssl.1.0.0.dylib (compatibility version 1.0.0, current version 1.0.0)
	/usr/local/opt/openssl/lib/libcrypto.1.0.0.dylib (compatibility version 1.0.0, current version 1.0.0)
	/opt/td-agent/embedded/lib/libz.1.dylib (compatibility version 1.0.0, current version 1.2.11)
```

After introduced this patch, librdkafka insists using our bundled
OpenSSL libraries:

```log
% otool -L /opt/td-agent//embedded/lib/ruby/gems/2.4.0/gems/rdkafka-0.7.0/ext/librdkafka.dylib
/opt/td-agent//embedded/lib/ruby/gems/2.4.0/gems/rdkafka-0.7.0/ext/librdkafka.dylib:
	/opt/td-agent/embedded/lib/ruby/gems/2.4.0/gems/rdkafka-0.7.0/ext/ports/x86_64-apple-darwin19.0.0/librdkafka/1.2.2-RC1/lib/librdkafka.1.dylib (compatibility version 0.0.0, current version 0.0.0)
	/usr/local/opt/lz4/lib/liblz4.1.dylib (compatibility version 1.0.0, current version 1.9.2)
	/usr/lib/libSystem.B.dylib (compatibility version 1.0.0, current version 1281.0.0)
	/usr/local/opt/zstd/lib/libzstd.1.dylib (compatibility version 1.0.0, current version 1.4.3)
	/usr/lib/libsasl2.2.dylib (compatibility version 3.0.0, current version 3.15.0)
	/opt/td-agent/embedded/lib/libssl.1.0.0.dylib (compatibility version 1.0.0, current version 1.0.0)
	/opt/td-agent/embedded/lib/libcrypto.1.0.0.dylib (compatibility version 1.0.0, current version 1.0.0)
	/opt/td-agent/embedded/lib/libz.1.dylib (compatibility version 1.0.0, current version 1.2.11)
```

Signed-off-by: Hiroshi Hatake <cosmo0920.oucc@gmail.com>