### PR TITLE
ext: Add build:git[ref] task for building librdkafka from a git sha

### DIFF
--- a/ext/Rakefile
+++ b/ext/Rakefile
@@ -55,3 +55,22 @@ task :clean do
   FileUtils.rm_rf File.join(File.dirname(__FILE__), "ports")
   FileUtils.rm_rf File.join(File.dirname(__FILE__), "tmp")
 end
+
+namespace :build do
+  desc "Build librdkafka at the given git sha or tag"
+  task :git, [:ref] do |task, args|
+    ref = args[:ref]
+    version = "git-#{ref}"
+
+    recipe = MiniPortile.new("librdkafka", version)
+    recipe.files << "https://github.com/edenhill/librdkafka/archive/#{ref}.tar.gz"
+    recipe.configure_options = ["--host=#{recipe.host}"]
+    recipe.cook
+
+    ext = recipe.host.include?("darwin") ? "dylib" : "so"
+    lib = File.expand_path("ports/#{recipe.host}/librdkafka/#{version}/lib/librdkafka.#{ext}", __dir__)
+
+    # Copy will copy the content, following any symlinks
+    FileUtils.cp(lib, __dir__)
+  end
+end


### PR DESCRIPTION
As part of some work to look into the build failures (see #98) I wanted
an easy way to run an automated bisect against different librdkafka
commits. This task is designed to be used during development and the
default task should still be used when installing the gem.

Examples:
```console
rake build:git[ff9478c62126]
rake build:git[v1.3.0-RC2]
```