### PR TITLE
Update Kafka to 2.2.1 for development and testing

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,18 +1,18 @@
-version: '2'
+version: "3"
+
 services:
   zookeeper:
     image: wurstmeister/zookeeper
-    ports:
-      - "2181:2181"
+
   kafka:
-    image: wurstmeister/kafka:1.0.1
+    # When bumping this also bump fallback in spec_helper.rb:12
+    image: "wurstmeister/kafka:2.12-2.2.1"
+    depends_on:
+      - zookeeper
     ports:
       - "9092:9092"
     environment:
-      KAFKA_ADVERTISED_HOST_NAME: localhost
-      KAFKA_ADVERTISED_PORT: 9092
+      KAFKA_ADVERTISED_HOST_NAME: 127.0.0.1
       KAFKA_ZOOKEEPER_CONNECT: zookeeper:2181
-      KAFKA_AUTO_CREATE_TOPICS_ENABLE: 'false'
+      KAFKA_HEAP_OPTS: "-Xmx512m -Xms512m"
       KAFKA_CREATE_TOPICS: "consume_test_topic:3:1,empty_test_topic:3:1,load_test_topic:3:1,produce_test_topic:3:1,rake_test_topic:3:1,watermarks_test_topic:3:1"
-    volumes:
-      - /var/run/docker.sock:/var/run/docker.sock

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -10,8 +10,8 @@ require "rdkafka"
 def rdkafka_config(config_overrides={})
   config = {
     :"api.version.request" => false,
-    :"broker.version.fallback" => "1.0",
-    :"bootstrap.servers" => "localhost:9092",
+    :"broker.version.fallback" => "2.2",
+    :"bootstrap.servers" => "127.0.0.1:9092",
     :"group.id" => "ruby-test-#{Random.new.rand(0..1_000_000)}",
     :"auto.offset.reset" => "earliest",
     :"enable.partition.eof" => false


### PR DESCRIPTION
Main goal was two fold: to update to a newer Kafka version to see if
that would fix some of the test failures and to simplify the config.
I've switched to using `127.0.0.1` instead of `localhost` as I was
getting connection failures using the hostname that may be related to
IPv6, switching to the IP made them disappear. I've also removed
KAFKA_ADVERTISED_PORT as it appears to be the default and
AUTO_CRETE_TOPICS_ENABLE as it looks to have been removed. Finally,
Zookeeper is no longer exposed as Kafka can connect to it within the
Docker network just fine. Linking to the docker socket file doesn't
appear to be necessary in this single broker case.

In testing, I was seeing tests pass just fine with 2.2.1 but failing
with 2.3.1.

Based on part of the work done in #98 