### PR TITLE
WIP: JRuby support

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -14,9 +14,21 @@ rvm:
   - 2.4
   - 2.5
   - 2.6
+  - jruby-9.2.9.0
 
 before_install:
   - gem update --system
+  - |
+    r_eng="$(ruby -e 'STDOUT.write RUBY_ENGINE')";
+    if [ "$r_eng" == "jruby" ]; then
+      sudo apt-get update && \
+      sudo apt-get install -y git && \
+      sudo apt-get install -y libpthread-stubs0-dev && \
+      sudo apt-get install -y build-essential && \
+      sudo apt-get install -y zlib1g-dev && \
+      sudo apt-get install -y libssl-dev && \
+      sudo apt-get install -y libsasl2-dev
+    fi
 
 before_script:
   - docker-compose up -d

--- a/.travis.yml
+++ b/.travis.yml
@@ -31,6 +31,8 @@ before_install:
     fi
 
 before_script:
+  - ulimit -S -n 65536
+  - ulimit -H -n 65536
   - docker-compose up -d
   - cd ext && bundle exec rake && cd ..
   - curl -L https://codeclimate.com/downloads/test-reporter/test-reporter-latest-linux-amd64 > ./cc-test-reporter

--- a/.travis.yml
+++ b/.travis.yml
@@ -31,8 +31,6 @@ before_install:
     fi
 
 before_script:
-  - ulimit -S -n 65536
-  - ulimit -H -n 65536
   - docker-compose up -d
   - cd ext && bundle exec rake && cd ..
   - curl -L https://codeclimate.com/downloads/test-reporter/test-reporter-latest-linux-amd64 > ./cc-test-reporter

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -4,11 +4,22 @@ services:
     image: wurstmeister/zookeeper
     ports:
       - "2181:2181"
+    ulimits:
+      nofile:
+        soft: "65536"
+        hard: "65536"
+    environment:
+      JAVA_OPTS: "-Xms1g -Xmx1g"
   kafka:
     image: wurstmeister/kafka:1.0.1
     ports:
       - "9092:9092"
+    ulimits:
+      nofile:
+        soft: "65536"
+        hard: "65536"
     environment:
+      JAVA_OPTS: "-Xms1g -Xmx1g"
       KAFKA_ADVERTISED_HOST_NAME: localhost
       KAFKA_ADVERTISED_PORT: 9092
       KAFKA_ZOOKEEPER_CONNECT: zookeeper:2181

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,29 +1,22 @@
+
 version: '2'
 services:
   zookeeper:
-    image: wurstmeister/zookeeper
-    ports:
-      - "2181:2181"
-    ulimits:
-      nofile:
-        soft: "65536"
-        hard: "65536"
+    image: confluentinc/cp-zookeeper:latest
     environment:
-      JAVA_OPTS: "-Xms1g -Xmx1g"
+      ZOOKEEPER_CLIENT_PORT: 2181
+      ZOOKEEPER_TICK_TIME: 2000
+
   kafka:
-    image: wurstmeister/kafka:1.0.1
+    image: confluentinc/cp-kafka:latest
+    depends_on:
+      - zookeeper
     ports:
-      - "9092:9092"
-    ulimits:
-      nofile:
-        soft: "65536"
-        hard: "65536"
+      - 9092:9092
     environment:
-      JAVA_OPTS: "-Xms1g -Xmx1g"
-      KAFKA_ADVERTISED_HOST_NAME: localhost
-      KAFKA_ADVERTISED_PORT: 9092
+      KAFKA_BROKER_ID: 1
       KAFKA_ZOOKEEPER_CONNECT: zookeeper:2181
-      KAFKA_AUTO_CREATE_TOPICS_ENABLE: 'false'
-      KAFKA_CREATE_TOPICS: "consume_test_topic:3:1,empty_test_topic:3:1,load_test_topic:3:1,produce_test_topic:3:1,rake_test_topic:3:1,watermarks_test_topic:3:1"
-    volumes:
-      - /var/run/docker.sock:/var/run/docker.sock
+      KAFKA_ADVERTISED_LISTENERS: PLAINTEXT://kafka:29092,PLAINTEXT_HOST://localhost:9092
+      KAFKA_LISTENER_SECURITY_PROTOCOL_MAP: PLAINTEXT:PLAINTEXT,PLAINTEXT_HOST:PLAINTEXT
+      KAFKA_INTER_BROKER_LISTENER_NAME: PLAINTEXT
+      KAFKA_OFFSETS_TOPIC_REPLICATION_FACTOR: 1

--- a/ext/Rakefile
+++ b/ext/Rakefile
@@ -24,7 +24,7 @@ task :default => :clean do
 
   # Use default homebrew openssl if we're on mac and the directory exists
   # and each of flags is not empty
-  if recipe.host.include?("darwin") && Dir.exists?("/usr/local/opt/openssl")
+  if recipe.host&.include?("darwin") && Dir.exist?("/usr/local/opt/openssl")
     ENV["CPPFLAGS"] = "-I/usr/local/opt/openssl/include" unless ENV["CPPFLAGS"]
     ENV["LDFLAGS"] = "-L/usr/local/opt/openssl/lib" unless ENV["LDFLAGS"]
   end

--- a/lib/rdkafka/bindings.rb
+++ b/lib/rdkafka/bindings.rb
@@ -8,7 +8,7 @@ module Rdkafka
     extend FFI::Library
 
     def self.lib_extension
-      if Gem::Platform.local.os.include?("darwin")
+      if RbConfig::CONFIG['host_os'] =~ /darwin/
         'dylib'
       else
         'so'

--- a/lib/rdkafka/config.rb
+++ b/lib/rdkafka/config.rb
@@ -212,10 +212,14 @@ module Rdkafka
         Rdkafka::Bindings.rd_kafka_queue_get_main(handle)
       )
 
-      FFI::AutoPointer.new(
-        handle,
-        Rdkafka::Bindings.method(:rd_kafka_destroy)
-      )
+      if type == :rd_kafka_consumer
+        handle
+      else
+        FFI::AutoPointer.new(
+          handle,
+          Rdkafka::Bindings.method(:rd_kafka_destroy)
+        )
+      end
     end
   end
 

--- a/lib/rdkafka/consumer.rb
+++ b/lib/rdkafka/consumer.rb
@@ -237,7 +237,7 @@ module Rdkafka
         raise Rdkafka::RdkafkaError.new(response, "Error querying watermark offsets for partition #{partition} of #{topic}")
       end
 
-      return low.read_int64, high.read_int64
+      return low.read_array_of_uint64(1).first, high.read_array_of_uint64(1).first
     ensure
       low.free
       high.free

--- a/lib/rdkafka/consumer.rb
+++ b/lib/rdkafka/consumer.rb
@@ -385,9 +385,7 @@ module Rdkafka
           raise Rdkafka::RdkafkaError.new(response)
         end
       ensure
-        if tpl
-          Rdkafka::Bindings.rd_kafka_topic_partition_list_destroy(tpl)
-        end
+        Rdkafka::Bindings.rd_kafka_topic_partition_list_destroy(tpl) if tpl
       end
     end
 
@@ -399,6 +397,8 @@ module Rdkafka
     #
     # @return [Message, nil] A message or nil if there was no new message within the timeout
     def poll(timeout_ms)
+      return if @closed
+
       message_ptr = Rdkafka::Bindings.rd_kafka_consumer_poll(@native_kafka, timeout_ms)
       if message_ptr.null?
         nil

--- a/lib/rdkafka/consumer.rb
+++ b/lib/rdkafka/consumer.rb
@@ -22,7 +22,6 @@ module Rdkafka
     def close
       @closing = true
       Rdkafka::Bindings.rd_kafka_consumer_close(@native_kafka)
-      @native_kafka.free
     end
 
     # Subscribe to one or more topics letting Kafka handle partition assignments.

--- a/lib/rdkafka/consumer.rb
+++ b/lib/rdkafka/consumer.rb
@@ -21,7 +21,6 @@ module Rdkafka
     # @return [nil]
     def close
       @closing = true
-      Rdkafka::Bindings.rd_kafka_consumer_close(@native_kafka)
       Rdkafka::Bindings.rd_kafka_destroy(@native_kafka)
     end
 

--- a/lib/rdkafka/consumer.rb
+++ b/lib/rdkafka/consumer.rb
@@ -13,7 +13,6 @@ module Rdkafka
 
     # @private
     def initialize(native_kafka)
-      @t1 = Time.now
       @native_kafka = native_kafka
       @closing = false
     end
@@ -23,7 +22,7 @@ module Rdkafka
     def close
       @closing = true
       Rdkafka::Bindings.rd_kafka_consumer_close(@native_kafka)
-      $stdout.puts "Closing consumer took: #{Time.now - @t1}"
+      Rdkafka::Bindings.rd_kafka_destroy(@native_kafka)
     end
 
     # Subscribe to one or more topics letting Kafka handle partition assignments.

--- a/lib/rdkafka/consumer.rb
+++ b/lib/rdkafka/consumer.rb
@@ -22,7 +22,7 @@ module Rdkafka
     def close
       @closing = true
       Rdkafka::Bindings.rd_kafka_consumer_close(@native_kafka)
-      Rdkafka::Bindings.rd_kafka_destroy(@native_kafka)
+      @native_kafka.free
     end
 
     # Subscribe to one or more topics letting Kafka handle partition assignments.

--- a/lib/rdkafka/consumer.rb
+++ b/lib/rdkafka/consumer.rb
@@ -24,6 +24,7 @@ module Rdkafka
 
       @closing = true
       Rdkafka::Bindings.rd_kafka_consumer_close(@native_kafka)
+      Rdkafka::Bindings.rd_kafka_destroy(@native_kafka)
       @closed = true
     end
 
@@ -82,6 +83,8 @@ module Rdkafka
         list = TopicPartitionList.from_native_tpl(tpl)
         raise Rdkafka::RdkafkaTopicPartitionListError.new(response, list, "Error pausing '#{list.to_h}'")
       end
+    ensure
+      Rdkafka::Bindings.rd_kafka_topic_partition_list_destroy(tpl)
     end
 
     # Resume producing consumption for the provided list of partitions
@@ -100,6 +103,8 @@ module Rdkafka
       if response != 0
         raise Rdkafka::RdkafkaError.new(response, "Error resume '#{list.to_h}'")
       end
+    ensure
+      Rdkafka::Bindings.rd_kafka_topic_partition_list_destroy(tpl)
     end
 
     # Return the current subscription to topics and partitions
@@ -114,7 +119,6 @@ module Rdkafka
         raise Rdkafka::RdkafkaError.new(response)
       end
 
-      tpl_ptrptr.autorelease = false
       tpl_ptr = tpl_ptrptr.read_pointer
 
       begin
@@ -152,7 +156,6 @@ module Rdkafka
         raise Rdkafka::RdkafkaError.new(response)
       end
 
-      tpl_ptrptr.autorelease = false
       tpl_ptr = tpl_ptrptr.read_pointer
 
       begin

--- a/lib/rdkafka/consumer.rb
+++ b/lib/rdkafka/consumer.rb
@@ -13,6 +13,7 @@ module Rdkafka
 
     # @private
     def initialize(native_kafka)
+      @t1 = Time.now
       @native_kafka = native_kafka
       @closing = false
     end
@@ -22,6 +23,7 @@ module Rdkafka
     def close
       @closing = true
       Rdkafka::Bindings.rd_kafka_consumer_close(@native_kafka)
+      $stdout.puts "Closing consumer took: #{Time.now - @t1}"
     end
 
     # Subscribe to one or more topics letting Kafka handle partition assignments.

--- a/lib/rdkafka/consumer.rb
+++ b/lib/rdkafka/consumer.rb
@@ -22,6 +22,7 @@ module Rdkafka
     def close
       @closing = true
       Rdkafka::Bindings.rd_kafka_consumer_close(@native_kafka)
+      Rdkafka::Bindings.rd_kafka_destroy(@native_kafka)
     end
 
     # Subscribe to one or more topics letting Kafka handle partition assignments.

--- a/lib/rdkafka/consumer.rb
+++ b/lib/rdkafka/consumer.rb
@@ -20,8 +20,11 @@ module Rdkafka
     # Close this consumer
     # @return [nil]
     def close
+      return if @closed
+
       @closing = true
-      Rdkafka::Bindings.rd_kafka_destroy(@native_kafka)
+      Rdkafka::Bindings.rd_kafka_consumer_close(@native_kafka)
+      @closed = true
     end
 
     # Subscribe to one or more topics letting Kafka handle partition assignments.

--- a/lib/rdkafka/consumer.rb
+++ b/lib/rdkafka/consumer.rb
@@ -118,7 +118,6 @@ module Rdkafka
         Rdkafka::Consumer::TopicPartitionList.from_native_tpl(tpl_ptr)
       ensure
         Rdkafka::Bindings.rd_kafka_topic_partition_list_destroy(tpl_ptr)
-        tpl_ptrptr.free
       end
     end
 
@@ -157,7 +156,6 @@ module Rdkafka
         Rdkafka::Consumer::TopicPartitionList.from_native_tpl(tpl_ptr)
       ensure
         Rdkafka::Bindings.rd_kafka_topic_partition_list_destroy(tpl_ptr)
-        tpl_ptrptr.free
       end
     end
 

--- a/lib/rdkafka/consumer.rb
+++ b/lib/rdkafka/consumer.rb
@@ -37,20 +37,19 @@ module Rdkafka
     # @return [nil]
     def subscribe(*topics)
       # Create topic partition list with topics and no partition set
-      tpl = TopicPartitionList.new_native_tpl(topics.length)
+      tpl = Rdkafka::Bindings.rd_kafka_topic_partition_list_new(topics.length)
 
       topics.each do |topic|
-        Rdkafka::Bindings.rd_kafka_topic_partition_list_add(
-          tpl,
-          topic,
-          -1
-        )
+        Rdkafka::Bindings.rd_kafka_topic_partition_list_add(tpl, topic, -1)
       end
+
       # Subscribe to topic partition list and check this was successful
       response = Rdkafka::Bindings.rd_kafka_subscribe(@native_kafka, tpl)
       if response != 0
         raise Rdkafka::RdkafkaError.new(response, "Error subscribing to '#{topics.join(', ')}'")
       end
+    ensure
+      Rdkafka::Bindings.rd_kafka_topic_partition_list_destroy(tpl)
     end
 
     # Unsubscribe from all subscribed topics.
@@ -76,15 +75,19 @@ module Rdkafka
       unless list.is_a?(TopicPartitionList)
         raise TypeError.new("list has to be a TopicPartitionList")
       end
-      tpl = list.to_native_tpl
-      response = Rdkafka::Bindings.rd_kafka_pause_partitions(@native_kafka, tpl)
 
-      if response != 0
-        list = TopicPartitionList.from_native_tpl(tpl)
-        raise Rdkafka::RdkafkaTopicPartitionListError.new(response, list, "Error pausing '#{list.to_h}'")
+      tpl = list.to_native_tpl
+
+      begin
+        response = Rdkafka::Bindings.rd_kafka_pause_partitions(@native_kafka, tpl)
+
+        if response != 0
+          list = TopicPartitionList.from_native_tpl(tpl)
+          raise Rdkafka::RdkafkaTopicPartitionListError.new(response, list, "Error pausing '#{list.to_h}'")
+        end
+      ensure
+        Rdkafka::Bindings.rd_kafka_topic_partition_list_destroy(tpl)
       end
-    ensure
-      Rdkafka::Bindings.rd_kafka_topic_partition_list_destroy(tpl)
     end
 
     # Resume producing consumption for the provided list of partitions
@@ -98,13 +101,17 @@ module Rdkafka
       unless list.is_a?(TopicPartitionList)
         raise TypeError.new("list has to be a TopicPartitionList")
       end
+
       tpl = list.to_native_tpl
-      response = Rdkafka::Bindings.rd_kafka_resume_partitions(@native_kafka, tpl)
-      if response != 0
-        raise Rdkafka::RdkafkaError.new(response, "Error resume '#{list.to_h}'")
+
+      begin
+        response = Rdkafka::Bindings.rd_kafka_resume_partitions(@native_kafka, tpl)
+        if response != 0
+          raise Rdkafka::RdkafkaError.new(response, "Error resume '#{list.to_h}'")
+        end
+      ensure
+        Rdkafka::Bindings.rd_kafka_topic_partition_list_destroy(tpl)
       end
-    ensure
-      Rdkafka::Bindings.rd_kafka_topic_partition_list_destroy(tpl)
     end
 
     # Return the current subscription to topics and partitions
@@ -113,18 +120,19 @@ module Rdkafka
     #
     # @return [TopicPartitionList]
     def subscription
-      tpl_ptrptr = FFI::MemoryPointer.new(:pointer)
-      response = Rdkafka::Bindings.rd_kafka_subscription(@native_kafka, tpl_ptrptr)
+      ptr = FFI::MemoryPointer.new(:pointer)
+      response = Rdkafka::Bindings.rd_kafka_subscription(@native_kafka, ptr)
+
       if response != 0
         raise Rdkafka::RdkafkaError.new(response)
       end
 
-      tpl_ptr = tpl_ptrptr.read_pointer
+      native = ptr.read_pointer
 
       begin
-        Rdkafka::Consumer::TopicPartitionList.from_native_tpl(tpl_ptr)
+        Rdkafka::Consumer::TopicPartitionList.from_native_tpl(native)
       ensure
-        Rdkafka::Bindings.rd_kafka_topic_partition_list_destroy(tpl_ptr)
+        Rdkafka::Bindings.rd_kafka_topic_partition_list_destroy(native)
       end
     end
 
@@ -137,10 +145,16 @@ module Rdkafka
       unless list.is_a?(TopicPartitionList)
         raise TypeError.new("list has to be a TopicPartitionList")
       end
+
       tpl = list.to_native_tpl
-      response = Rdkafka::Bindings.rd_kafka_assign(@native_kafka, tpl)
-      if response != 0
-        raise Rdkafka::RdkafkaError.new(response, "Error assigning '#{list.to_h}'")
+
+      begin
+        response = Rdkafka::Bindings.rd_kafka_assign(@native_kafka, tpl)
+        if response != 0
+          raise Rdkafka::RdkafkaError.new(response, "Error assigning '#{list.to_h}'")
+        end
+      ensure
+        Rdkafka::Bindings.rd_kafka_topic_partition_list_destroy(tpl)
       end
     end
 
@@ -150,19 +164,23 @@ module Rdkafka
     #
     # @return [TopicPartitionList]
     def assignment
-      tpl_ptrptr = FFI::MemoryPointer.new(:pointer)
-      response = Rdkafka::Bindings.rd_kafka_assignment(@native_kafka, tpl_ptrptr)
+      ptr = FFI::MemoryPointer.new(:pointer)
+      response = Rdkafka::Bindings.rd_kafka_assignment(@native_kafka, ptr)
       if response != 0
         raise Rdkafka::RdkafkaError.new(response)
       end
 
-      tpl_ptr = tpl_ptrptr.read_pointer
+      tpl = ptr.read_pointer
 
-      begin
-        Rdkafka::Consumer::TopicPartitionList.from_native_tpl(tpl_ptr)
-      ensure
-        Rdkafka::Bindings.rd_kafka_topic_partition_list_destroy(tpl_ptr)
+      if !tpl.null?
+        begin
+          Rdkafka::Consumer::TopicPartitionList.from_native_tpl(tpl)
+        ensure
+          Rdkafka::Bindings.rd_kafka_topic_partition_list_destroy tpl
+        end
       end
+    ensure
+      ptr.free
     end
 
     # Return the current committed offset per partition for this consumer group.
@@ -180,12 +198,18 @@ module Rdkafka
       elsif !list.is_a?(TopicPartitionList)
         raise TypeError.new("list has to be nil or a TopicPartitionList")
       end
+
       tpl = list.to_native_tpl
-      response = Rdkafka::Bindings.rd_kafka_committed(@native_kafka, tpl, timeout_ms)
-      if response != 0
-        raise Rdkafka::RdkafkaError.new(response)
+
+      begin
+        response = Rdkafka::Bindings.rd_kafka_committed(@native_kafka, tpl, timeout_ms)
+        if response != 0
+          raise Rdkafka::RdkafkaError.new(response)
+        end
+        TopicPartitionList.from_native_tpl(tpl)
+      ensure
+        Rdkafka::Bindings.rd_kafka_topic_partition_list_destroy(tpl)
       end
-      TopicPartitionList.from_native_tpl(tpl)
     end
 
     # Query broker for low (oldest/beginning) and high (newest/end) offsets for a partition.
@@ -207,13 +231,16 @@ module Rdkafka
         partition,
         low,
         high,
-        timeout_ms
+        timeout_ms,
       )
       if response != 0
         raise Rdkafka::RdkafkaError.new(response, "Error querying watermark offsets for partition #{partition} of #{topic}")
       end
 
-      return low.read_array_of_uint64(1).first, high.read_array_of_uint64(1).first
+      return low.read_int64, high.read_int64
+    ensure
+      low.free
+      high.free
     end
 
     # Calculate the consumer lag per partition for the provided topic partition list.
@@ -229,6 +256,7 @@ module Rdkafka
     # @return [Hash<String, Hash<Integer, Integer>>] A hash containing all topics with the lag per partition
     def lag(topic_partition_list, watermark_timeout_ms=100)
       out = {}
+
       topic_partition_list.to_h.each do |topic, partitions|
         # Query high watermarks for this topic's partitions
         # and compare to the offset in the list.
@@ -344,14 +372,22 @@ module Rdkafka
       if !list.nil? && !list.is_a?(TopicPartitionList)
         raise TypeError.new("list has to be nil or a TopicPartitionList")
       end
+
       tpl = if list
               list.to_native_tpl
             else
               nil
             end
-      response = Rdkafka::Bindings.rd_kafka_commit(@native_kafka, tpl, async)
-      if response != 0
-        raise Rdkafka::RdkafkaError.new(response)
+
+      begin
+        response = Rdkafka::Bindings.rd_kafka_commit(@native_kafka, tpl, async)
+        if response != 0
+          raise Rdkafka::RdkafkaError.new(response)
+        end
+      ensure
+        if tpl
+          Rdkafka::Bindings.rd_kafka_topic_partition_list_destroy(tpl)
+        end
       end
     end
 

--- a/lib/rdkafka/consumer.rb
+++ b/lib/rdkafka/consumer.rb
@@ -21,7 +21,7 @@ module Rdkafka
     # @return [nil]
     def close
       @closing = true
-      Rdkafka::Bindings.rd_kafka_consumer_close(@native_kafka)
+      @native_kafka = nil
     end
 
     # Subscribe to one or more topics letting Kafka handle partition assignments.

--- a/lib/rdkafka/consumer.rb
+++ b/lib/rdkafka/consumer.rb
@@ -21,7 +21,7 @@ module Rdkafka
     # @return [nil]
     def close
       @closing = true
-      @native_kafka = nil
+      Rdkafka::Bindings.rd_kafka_consumer_close(@native_kafka)
     end
 
     # Subscribe to one or more topics letting Kafka handle partition assignments.

--- a/lib/rdkafka/consumer/headers.rb
+++ b/lib/rdkafka/consumer/headers.rb
@@ -62,9 +62,7 @@ module Rdkafka
 
         headers
       ensure
-        name_ptr.free if defined?(name_ptr) && name_ptr
         name_ptrptr.free if defined?(name_ptrptr) && name_ptrptr
-        value_ptr.free if defined?(value_ptr) && value_ptr
         value_ptrptr.free if defined?(value_ptrptr) && value_ptrptr
       end
     end

--- a/lib/rdkafka/consumer/headers.rb
+++ b/lib/rdkafka/consumer/headers.rb
@@ -19,7 +19,6 @@ module Rdkafka
           raise Rdkafka::RdkafkaError.new(err, "Error reading message headers")
         end
 
-        headers_ptrptr.autorelease = false
         headers_ptr = headers_ptrptr.read_pointer
 
         name_ptrptr = FFI::MemoryPointer.new(:pointer)
@@ -43,14 +42,12 @@ module Rdkafka
             raise Rdkafka::RdkafkaError.new(err, "Error reading a message header at index #{idx}")
           end
 
-          name_ptrptr.autorelease = false
           name_ptr = name_ptrptr.read_pointer
 
           name = name_ptr.respond_to?(:read_string_to_null) ? name_ptr.read_string_to_null : name_ptr.read_string
 
           size = size_ptr[:value]
 
-          value_ptrptr.autorelease = false
           value_ptr = value_ptrptr.read_pointer
 
           value = value_ptr.read_string(size)
@@ -62,8 +59,9 @@ module Rdkafka
 
         headers
       ensure
-        name_ptrptr.free if defined?(name_ptrptr) && name_ptrptr
-        value_ptrptr.free if defined?(value_ptrptr) && value_ptrptr
+        headers_ptr.free
+        name_ptr.free
+        value_ptr.free
       end
     end
   end

--- a/lib/rdkafka/consumer/topic_partition_list.rb
+++ b/lib/rdkafka/consumer/topic_partition_list.rb
@@ -128,7 +128,7 @@ module Rdkafka
       # @return [FFI::AutoPointer]
       # @private
       def to_native_tpl
-        tpl = TopicPartitionList.new_native_tpl(count)
+        tpl = Rdkafka::Bindings.rd_kafka_topic_partition_list_new(count)
 
         @data.each do |topic, partitions|
           if partitions
@@ -138,6 +138,7 @@ module Rdkafka
                 topic,
                 p.partition
               )
+
               if p.offset
                 Rdkafka::Bindings.rd_kafka_topic_partition_list_set_offset(
                   tpl,
@@ -157,16 +158,6 @@ module Rdkafka
         end
 
         tpl
-      end
-
-      # Creates a new native tpl and wraps it into FFI::AutoPointer which in turn calls
-      # `rd_kafka_topic_partition_list_destroy` when a pointer will be cleaned by GC
-      #
-      # @param count [Integer] an initial capacity of partitions list
-      # @return [FFI::AutoPointer]
-      # @private
-      def self.new_native_tpl(count)
-        Rdkafka::Bindings.rd_kafka_topic_partition_list_new(count)
       end
     end
   end

--- a/lib/rdkafka/consumer/topic_partition_list.rb
+++ b/lib/rdkafka/consumer/topic_partition_list.rb
@@ -166,8 +166,7 @@ module Rdkafka
       # @return [FFI::AutoPointer]
       # @private
       def self.new_native_tpl(count)
-        tpl = Rdkafka::Bindings.rd_kafka_topic_partition_list_new(count)
-        FFI::AutoPointer.new(tpl, Rdkafka::Bindings.method(:rd_kafka_topic_partition_list_destroy))
+        Rdkafka::Bindings.rd_kafka_topic_partition_list_new(count)
       end
     end
   end

--- a/lib/rdkafka/error.rb
+++ b/lib/rdkafka/error.rb
@@ -39,6 +39,11 @@ module Rdkafka
     def is_partition_eof?
       code == :partition_eof
     end
+
+    # Error comparison
+    def ==(another_error)
+       another_error.is_a?(self.class) && (self.to_s == another_error.to_s)
+    end
   end
 
   # Error with topic partition list returned by the underlying rdkafka library.

--- a/lib/rdkafka/producer.rb
+++ b/lib/rdkafka/producer.rb
@@ -41,7 +41,6 @@ module Rdkafka
       @closing = true
       # Wait for the polling thread to finish up
       @polling_thread.join
-      @native_kafka.free
     end
 
     # Produces a message to a Kafka topic. The message is added to rdkafka's queue, call {DeliveryHandle#wait wait} on the returned delivery handle to make sure it is delivered.

--- a/lib/rdkafka/producer.rb
+++ b/lib/rdkafka/producer.rb
@@ -41,7 +41,7 @@ module Rdkafka
       @closing = true
       # Wait for the polling thread to finish up
       @polling_thread.join
-      Rdkafka::Bindings.rd_kafka_destroy(@native_kafka)
+      @native_kafka.free
     end
 
     # Produces a message to a Kafka topic. The message is added to rdkafka's queue, call {DeliveryHandle#wait wait} on the returned delivery handle to make sure it is delivered.

--- a/lib/rdkafka/producer.rb
+++ b/lib/rdkafka/producer.rb
@@ -9,6 +9,7 @@ module Rdkafka
 
     # @private
     def initialize(native_kafka)
+      @t1 = Time.now
       @closing = false
       @native_kafka = native_kafka
       # Start thread to poll client for delivery callbacks
@@ -16,8 +17,11 @@ module Rdkafka
         loop do
           Rdkafka::Bindings.rd_kafka_poll(@native_kafka, 250)
           # Exit thread if closing and the poll queue is empty
-          if @closing && Rdkafka::Bindings.rd_kafka_outq_len(@native_kafka) == 0
+          len = Rdkafka::Bindings.rd_kafka_outq_len(@native_kafka)
+          if @closing && len == 0
             break
+          else
+            $stdout.puts "Len: #{len}"
           end
         end
       end
@@ -41,6 +45,7 @@ module Rdkafka
       @closing = true
       # Wait for the polling thread to finish up
       @polling_thread.join
+      $stdout.puts "Closing producer took: #{Time.now - @t1}"
     end
 
     # Produces a message to a Kafka topic. The message is added to rdkafka's queue, call {DeliveryHandle#wait wait} on the returned delivery handle to make sure it is delivered.

--- a/spec/rdkafka/bindings_spec.rb
+++ b/spec/rdkafka/bindings_spec.rb
@@ -7,12 +7,12 @@ describe Rdkafka::Bindings do
 
   describe ".lib_extension" do
     it "should know the lib extension for darwin" do
-      expect(Gem::Platform.local).to receive(:os).and_return("darwin-aaa")
+      stub_const('RbConfig::CONFIG', 'host_os' =>'darwin')
       expect(Rdkafka::Bindings.lib_extension).to eq "dylib"
     end
 
     it "should know the lib extension for linux" do
-      expect(Gem::Platform.local).to receive(:os).and_return("linux")
+      stub_const('RbConfig::CONFIG', 'host_os' =>'linux')
       expect(Rdkafka::Bindings.lib_extension).to eq "so"
     end
   end

--- a/spec/rdkafka/consumer_spec.rb
+++ b/spec/rdkafka/consumer_spec.rb
@@ -557,12 +557,12 @@ describe Rdkafka::Consumer do
         payload:   "payload 1",
         key:       "key 1"
       ).wait
-
       consumer.subscribe("consume_test_topic")
-      message = consumer.poll(5000)
-      expect(message).to be_a Rdkafka::Consumer::Message
+      message = consumer.each {|m| break m}
 
-      # Message content is tested in producer spec
+      expect(message).to be_a Rdkafka::Consumer::Message
+      expect(message.payload).to eq('payload 1')
+      expect(message.key).to eq('key 1')
     end
 
     it "should raise an error when polling fails" do

--- a/spec/rdkafka/consumer_spec.rb
+++ b/spec/rdkafka/consumer_spec.rb
@@ -6,8 +6,12 @@ describe Rdkafka::Consumer do
   let(:consumer) { config.consumer }
   let(:producer) { config.producer }
 
-  describe "#subscripe, #unsubscribe and #subscription" do
+  after { consumer.close }
+  after { producer.close }
+
+  describe "#subscribe, #unsubscribe and #subscription" do
     it "should subscribe, unsubscribe and return the subscription" do
+      # trace.enable
       expect(consumer.subscription).to be_empty
 
       consumer.subscribe("consume_test_topic")
@@ -316,7 +320,6 @@ describe Rdkafka::Consumer do
     context "with a commited consumer" do
       before :all do
         # Make sure there are some message
-        producer = rdkafka_config.producer
         handles = []
         10.times do
           (0..2).each do |i|

--- a/spec/rdkafka/consumer_spec.rb
+++ b/spec/rdkafka/consumer_spec.rb
@@ -207,8 +207,6 @@ describe Rdkafka::Consumer do
         expect(records&.payload).to eq "payload c"
         records = consumer.poll(timeout)
         expect(records).to be_nil
-
-        consumer.commit
       end
     end
   end

--- a/spec/rdkafka/consumer_spec.rb
+++ b/spec/rdkafka/consumer_spec.rb
@@ -11,7 +11,6 @@ describe Rdkafka::Consumer do
 
   describe "#subscribe, #unsubscribe and #subscription" do
     it "should subscribe, unsubscribe and return the subscription" do
-      # trace.enable
       expect(consumer.subscription).to be_empty
 
       consumer.subscribe("consume_test_topic")
@@ -321,6 +320,7 @@ describe Rdkafka::Consumer do
       before :all do
         # Make sure there are some message
         handles = []
+        producer = rdkafka_config.producer
         10.times do
           (0..2).each do |i|
             handles << producer.produce(

--- a/spec/rdkafka/consumer_spec.rb
+++ b/spec/rdkafka/consumer_spec.rb
@@ -91,7 +91,6 @@ describe Rdkafka::Consumer do
         # 8. ensure that message is successfully consumed
         records = consumer.poll(timeout)
         expect(records).not_to be_nil
-        consumer.commit
       end
     end
 

--- a/spec/rdkafka/error_spec.rb
+++ b/spec/rdkafka/error_spec.rb
@@ -71,15 +71,15 @@ describe Rdkafka::RdkafkaError do
     end
 
     it "should not equal another error with a different error code" do
-      expect(subject).to eq Rdkafka::RdkafkaError.new(20, "Error explanation")
+      expect(subject).not_to eq Rdkafka::RdkafkaError.new(20, "Error explanation")
     end
 
     it "should not equal another error with a different message" do
-      expect(subject).to eq Rdkafka::RdkafkaError.new(10, "Different error explanation")
+      expect(subject).not_to eq Rdkafka::RdkafkaError.new(10, "Different error explanation")
     end
 
     it "should not equal another error with no message" do
-      expect(subject).to eq Rdkafka::RdkafkaError.new(10)
+      expect(subject).not_to eq Rdkafka::RdkafkaError.new(10)
     end
   end
 end

--- a/spec/rdkafka/producer_spec.rb
+++ b/spec/rdkafka/producer_spec.rb
@@ -284,6 +284,9 @@ describe Rdkafka::Producer do
     # Fork, produce a message, send the report over a pipe and
     # wait for and check the message in the main process.
 
+    # Kernel#fork is not available in JRuby
+    skip if defined?(JRUBY_VERSION)
+
     reader, writer = IO.pipe
 
     fork do

--- a/spec/rdkafka/producer_spec.rb
+++ b/spec/rdkafka/producer_spec.rb
@@ -42,7 +42,7 @@ describe Rdkafka::Producer do
       )
 
       # Wait for it to be delivered
-      handle.wait(max_wait_timeout: 5)
+      handle.wait(max_wait_timeout: 8)
 
       # Callback should have been called
       expect(@callback_called).to be true

--- a/spec/rdkafka/producer_spec.rb
+++ b/spec/rdkafka/producer_spec.rb
@@ -285,7 +285,7 @@ describe Rdkafka::Producer do
     # wait for and check the message in the main process.
 
     # Kernel#fork is not available in JRuby
-    skip #if defined?(JRUBY_VERSION)
+    skip if defined?(JRUBY_VERSION)
 
     reader, writer = IO.pipe
 

--- a/spec/rdkafka/producer_spec.rb
+++ b/spec/rdkafka/producer_spec.rb
@@ -289,6 +289,12 @@ describe Rdkafka::Producer do
 
     reader, writer = IO.pipe
 
+    producer.close
+    producer.instance_eval {@native_kafka = nil}
+    # For GC'ing @native_kafka references here to avoid finalizer being called in the forked process.
+    GC.start
+    sleep 0.1
+
     fork do
       reader.close
 

--- a/spec/rdkafka/producer_spec.rb
+++ b/spec/rdkafka/producer_spec.rb
@@ -89,7 +89,7 @@ describe Rdkafka::Producer do
     expect(message.key).to eq "key"
     # Since api.version.request is on by default we will get
     # the message creation timestamp if it's not set.
-    expect(message.timestamp).to be_within(5).of(Time.now)
+    expect(message.timestamp).to be_within(8).of(Time.now)
   end
 
   it "should produce a message with a specified partition" do

--- a/spec/rdkafka/producer_spec.rb
+++ b/spec/rdkafka/producer_spec.rb
@@ -285,7 +285,7 @@ describe Rdkafka::Producer do
     # wait for and check the message in the main process.
 
     # Kernel#fork is not available in JRuby
-    skip if defined?(JRUBY_VERSION)
+    skip #if defined?(JRUBY_VERSION)
 
     reader, writer = IO.pipe
 

--- a/spec/rdkafka/producer_spec.rb
+++ b/spec/rdkafka/producer_spec.rb
@@ -42,7 +42,7 @@ describe Rdkafka::Producer do
       )
 
       # Wait for it to be delivered
-      handle.wait(max_wait_timeout: 8)
+      handle.wait(max_wait_timeout: 5)
 
       # Callback should have been called
       expect(@callback_called).to be true

--- a/spec/rdkafka/producer_spec.rb
+++ b/spec/rdkafka/producer_spec.rb
@@ -42,7 +42,7 @@ describe Rdkafka::Producer do
       )
 
       # Wait for it to be delivered
-      handle.wait(max_wait_timeout: 5)
+      handle.wait(max_wait_timeout: 10)
 
       # Callback should have been called
       expect(@callback_called).to be true

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -7,6 +7,12 @@ require "pry"
 require "rspec"
 require "rdkafka"
 
+`docker-compose exec kafka kafka-topics --create --zookeeper zookeeper:2181 --replication-factor 1 --partitions 3 --if-not-exists --topic consume_test_topic`
+`docker-compose exec kafka kafka-topics --create --zookeeper zookeeper:2181 --replication-factor 1 --partitions 3 --if-not-exists --topic empty_test_topic`
+`docker-compose exec kafka kafka-topics --create --zookeeper zookeeper:2181 --replication-factor 1 --partitions 3 --if-not-exists --topic load_test_topic`
+`docker-compose exec kafka kafka-topics --create --zookeeper zookeeper:2181 --replication-factor 1 --partitions 3 --if-not-exists --topic produce_test_topic`
+`docker-compose exec kafka kafka-topics --create --zookeeper zookeeper:2181 --replication-factor 1 --partitions 3 --if-not-exists --topic rake_test_topic`
+
 def rdkafka_config(config_overrides={})
   config = {
     :"api.version.request" => false,
@@ -66,11 +72,5 @@ def wait_for_unassignment(consumer)
   10.times do
     break if consumer.assignment.empty?
     sleep 1
-  end
-end
-
-def trace
-  @trace ||= TracePoint.new do |tp|
-    p "Path: #{tp.path}##{tp.lineno}, Method:#{tp.method_id}, Event: #{tp.event}" unless tp.path.include? 'rspec'
   end
 end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -68,3 +68,9 @@ def wait_for_unassignment(consumer)
     sleep 1
   end
 end
+
+def trace
+  @trace ||= TracePoint.new do |tp|
+    p "Path: #{tp.path}##{tp.lineno}, Method:#{tp.method_id}, Event: #{tp.event}" unless tp.path.include? 'rspec'
+  end
+end


### PR DESCRIPTION
**Thanks for the library.**

I came across https://github.com/karafka/karafka/issues/433#issuecomment-442762051 and assumed that the maintainers would be willing to support JRuby as `rdkafka-ruby` appears to be the future backend for gems like `karafka, racecar etc.`

**The changes in this PR include:**
1. Work-arounds for the lack of `read_int64, read(:pointer), read_string_to_null`.
2. Work-around for `Pointer#autorelease=`.
3. Tweaking the timeout in `producer_spec` to avoid intermittent failures.
4. Use *_ptrptr for references to MemoryPointer to match with https://github.com/appsignal/rdkafka-ruby/blob/d0d71f669daadbfeec056085b8abe065478be784/lib/rdkafka/consumer/headers.rb#L13

The lack of these methods probably could be fixed by https://github.com/jruby/jruby/issues/5947.

`Pointer#autorelease=` is not available which was introduced in https://github.com/appsignal/rdkafka-ruby/pull/73. I tried to manually free them within the `ensure` blocks.

I'm don't think [this](https://github.com/Adithya-copart/rdkafka-ruby/blob/06cf5ff05059a51651ebe52644f0110dac185dc8/lib/rdkafka/consumer/headers.rb#L65-L68) is necessary as the `*_ptrptr` and `*_ptr` appear to be freed by the time ensure blocks are being run.