### PR TITLE
Support JRuby and fix travis failures

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -14,9 +14,21 @@ rvm:
   - 2.4
   - 2.5
   - 2.6
+  - jruby-9.2.9.0
 
 before_install:
   - gem update --system
+  - |
+    r_eng="$(ruby -e 'STDOUT.write RUBY_ENGINE')";
+    if [ "$r_eng" == "jruby" ]; then
+      sudo apt-get update && \
+      sudo apt-get install -y git && \
+      sudo apt-get install -y libpthread-stubs0-dev && \
+      sudo apt-get install -y build-essential && \
+      sudo apt-get install -y zlib1g-dev && \
+      sudo apt-get install -y libssl-dev && \
+      sudo apt-get install -y libsasl2-dev
+    fi
 
 before_script:
   - docker-compose up -d

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,18 +1,22 @@
+
 version: '2'
 services:
   zookeeper:
-    image: wurstmeister/zookeeper
-    ports:
-      - "2181:2181"
-  kafka:
-    image: wurstmeister/kafka:1.0.1
-    ports:
-      - "9092:9092"
+    image: confluentinc/cp-zookeeper:latest
     environment:
-      KAFKA_ADVERTISED_HOST_NAME: localhost
-      KAFKA_ADVERTISED_PORT: 9092
+      ZOOKEEPER_CLIENT_PORT: 2181
+      ZOOKEEPER_TICK_TIME: 2000
+
+  kafka:
+    image: confluentinc/cp-kafka:latest
+    depends_on:
+      - zookeeper
+    ports:
+      - 9092:9092
+    environment:
+      KAFKA_BROKER_ID: 1
       KAFKA_ZOOKEEPER_CONNECT: zookeeper:2181
-      KAFKA_AUTO_CREATE_TOPICS_ENABLE: 'false'
-      KAFKA_CREATE_TOPICS: "consume_test_topic:3:1,empty_test_topic:3:1,load_test_topic:3:1,produce_test_topic:3:1,rake_test_topic:3:1,watermarks_test_topic:3:1"
-    volumes:
-      - /var/run/docker.sock:/var/run/docker.sock
+      KAFKA_ADVERTISED_LISTENERS: PLAINTEXT://kafka:29092,PLAINTEXT_HOST://localhost:9092
+      KAFKA_LISTENER_SECURITY_PROTOCOL_MAP: PLAINTEXT:PLAINTEXT,PLAINTEXT_HOST:PLAINTEXT
+      KAFKA_INTER_BROKER_LISTENER_NAME: PLAINTEXT
+      KAFKA_OFFSETS_TOPIC_REPLICATION_FACTOR: 1

--- a/ext/Rakefile
+++ b/ext/Rakefile
@@ -24,7 +24,7 @@ task :default => :clean do
 
   # Use default homebrew openssl if we're on mac and the directory exists
   # and each of flags is not empty
-  if recipe.host.include?("darwin") && Dir.exists?("/usr/local/opt/openssl")
+  if recipe.host&.include?("darwin") && Dir.exist?("/usr/local/opt/openssl")
     ENV["CPPFLAGS"] = "-I/usr/local/opt/openssl/include" unless ENV["CPPFLAGS"]
     ENV["LDFLAGS"] = "-L/usr/local/opt/openssl/lib" unless ENV["LDFLAGS"]
   end

--- a/lib/rdkafka/bindings.rb
+++ b/lib/rdkafka/bindings.rb
@@ -8,7 +8,7 @@ module Rdkafka
     extend FFI::Library
 
     def self.lib_extension
-      if Gem::Platform.local.os.include?("darwin")
+      if RbConfig::CONFIG['host_os'] =~ /darwin/
         'dylib'
       else
         'so'

--- a/lib/rdkafka/config.rb
+++ b/lib/rdkafka/config.rb
@@ -212,14 +212,10 @@ module Rdkafka
         Rdkafka::Bindings.rd_kafka_queue_get_main(handle)
       )
 
-      if type == :rd_kafka_consumer
-        handle
-      else
-        FFI::AutoPointer.new(
-          handle,
-          Rdkafka::Bindings.method(:rd_kafka_destroy)
-        )
-      end
+      FFI::AutoPointer.new(
+        handle,
+        Rdkafka::Bindings.method(:rd_kafka_destroy)
+      )
     end
   end
 

--- a/lib/rdkafka/config.rb
+++ b/lib/rdkafka/config.rb
@@ -212,10 +212,14 @@ module Rdkafka
         Rdkafka::Bindings.rd_kafka_queue_get_main(handle)
       )
 
-      FFI::AutoPointer.new(
-        handle,
-        Rdkafka::Bindings.method(:rd_kafka_destroy)
-      )
+      if type == :rd_kafka_consumer
+        handle
+      else
+        FFI::AutoPointer.new(
+          handle,
+          Rdkafka::Bindings.method(:rd_kafka_destroy)
+        )
+      end
     end
   end
 

--- a/lib/rdkafka/config.rb
+++ b/lib/rdkafka/config.rb
@@ -212,10 +212,8 @@ module Rdkafka
         Rdkafka::Bindings.rd_kafka_queue_get_main(handle)
       )
 
-      FFI::AutoPointer.new(
-        handle,
-        Rdkafka::Bindings.method(:rd_kafka_destroy)
-      )
+      # Return handle which should be closed using rd_kafka_destroy after usage.
+      handle
     end
   end
 

--- a/lib/rdkafka/consumer.rb
+++ b/lib/rdkafka/consumer.rb
@@ -24,7 +24,7 @@ module Rdkafka
 
       @closing = true
       Rdkafka::Bindings.rd_kafka_consumer_close(@native_kafka)
-      @native_kafka.free
+      Rdkafka::Bindings.rd_kafka_destroy(@native_kafka)
       @closed = true
     end
 

--- a/lib/rdkafka/consumer.rb
+++ b/lib/rdkafka/consumer.rb
@@ -24,7 +24,7 @@ module Rdkafka
 
       @closing = true
       Rdkafka::Bindings.rd_kafka_consumer_close(@native_kafka)
-      Rdkafka::Bindings.rd_kafka_destroy(@native_kafka)
+      @native_kafka.free
       @closed = true
     end
 
@@ -237,7 +237,7 @@ module Rdkafka
         raise Rdkafka::RdkafkaError.new(response, "Error querying watermark offsets for partition #{partition} of #{topic}")
       end
 
-      return low.read_array_of_uint64(1).first, high.read_array_of_uint64(1).first
+      return low.read_array_of_int64(1).first, high.read_array_of_int64(1).first
     ensure
       low.free
       high.free

--- a/lib/rdkafka/consumer.rb
+++ b/lib/rdkafka/consumer.rb
@@ -37,20 +37,19 @@ module Rdkafka
     # @return [nil]
     def subscribe(*topics)
       # Create topic partition list with topics and no partition set
-      tpl = TopicPartitionList.new_native_tpl(topics.length)
+      tpl = Rdkafka::Bindings.rd_kafka_topic_partition_list_new(topics.length)
 
       topics.each do |topic|
-        Rdkafka::Bindings.rd_kafka_topic_partition_list_add(
-          tpl,
-          topic,
-          -1
-        )
+        Rdkafka::Bindings.rd_kafka_topic_partition_list_add(tpl, topic, -1)
       end
+
       # Subscribe to topic partition list and check this was successful
       response = Rdkafka::Bindings.rd_kafka_subscribe(@native_kafka, tpl)
       if response != 0
         raise Rdkafka::RdkafkaError.new(response, "Error subscribing to '#{topics.join(', ')}'")
       end
+    ensure
+      Rdkafka::Bindings.rd_kafka_topic_partition_list_destroy(tpl)
     end
 
     # Unsubscribe from all subscribed topics.
@@ -76,15 +75,19 @@ module Rdkafka
       unless list.is_a?(TopicPartitionList)
         raise TypeError.new("list has to be a TopicPartitionList")
       end
-      tpl = list.to_native_tpl
-      response = Rdkafka::Bindings.rd_kafka_pause_partitions(@native_kafka, tpl)
 
-      if response != 0
-        list = TopicPartitionList.from_native_tpl(tpl)
-        raise Rdkafka::RdkafkaTopicPartitionListError.new(response, list, "Error pausing '#{list.to_h}'")
+      tpl = list.to_native_tpl
+
+      begin
+        response = Rdkafka::Bindings.rd_kafka_pause_partitions(@native_kafka, tpl)
+
+        if response != 0
+          list = TopicPartitionList.from_native_tpl(tpl)
+          raise Rdkafka::RdkafkaTopicPartitionListError.new(response, list, "Error pausing '#{list.to_h}'")
+        end
+      ensure
+        Rdkafka::Bindings.rd_kafka_topic_partition_list_destroy(tpl)
       end
-    ensure
-      Rdkafka::Bindings.rd_kafka_topic_partition_list_destroy(tpl)
     end
 
     # Resume producing consumption for the provided list of partitions
@@ -98,13 +101,17 @@ module Rdkafka
       unless list.is_a?(TopicPartitionList)
         raise TypeError.new("list has to be a TopicPartitionList")
       end
+
       tpl = list.to_native_tpl
-      response = Rdkafka::Bindings.rd_kafka_resume_partitions(@native_kafka, tpl)
-      if response != 0
-        raise Rdkafka::RdkafkaError.new(response, "Error resume '#{list.to_h}'")
+
+      begin
+        response = Rdkafka::Bindings.rd_kafka_resume_partitions(@native_kafka, tpl)
+        if response != 0
+          raise Rdkafka::RdkafkaError.new(response, "Error resume '#{list.to_h}'")
+        end
+      ensure
+        Rdkafka::Bindings.rd_kafka_topic_partition_list_destroy(tpl)
       end
-    ensure
-      Rdkafka::Bindings.rd_kafka_topic_partition_list_destroy(tpl)
     end
 
     # Return the current subscription to topics and partitions
@@ -113,18 +120,19 @@ module Rdkafka
     #
     # @return [TopicPartitionList]
     def subscription
-      tpl_ptrptr = FFI::MemoryPointer.new(:pointer)
-      response = Rdkafka::Bindings.rd_kafka_subscription(@native_kafka, tpl_ptrptr)
+      ptr = FFI::MemoryPointer.new(:pointer)
+      response = Rdkafka::Bindings.rd_kafka_subscription(@native_kafka, ptr)
+
       if response != 0
         raise Rdkafka::RdkafkaError.new(response)
       end
 
-      tpl_ptr = tpl_ptrptr.read_pointer
+      native = ptr.read_pointer
 
       begin
-        Rdkafka::Consumer::TopicPartitionList.from_native_tpl(tpl_ptr)
+        Rdkafka::Consumer::TopicPartitionList.from_native_tpl(native)
       ensure
-        Rdkafka::Bindings.rd_kafka_topic_partition_list_destroy(tpl_ptr)
+        Rdkafka::Bindings.rd_kafka_topic_partition_list_destroy(native)
       end
     end
 
@@ -137,10 +145,16 @@ module Rdkafka
       unless list.is_a?(TopicPartitionList)
         raise TypeError.new("list has to be a TopicPartitionList")
       end
+
       tpl = list.to_native_tpl
-      response = Rdkafka::Bindings.rd_kafka_assign(@native_kafka, tpl)
-      if response != 0
-        raise Rdkafka::RdkafkaError.new(response, "Error assigning '#{list.to_h}'")
+
+      begin
+        response = Rdkafka::Bindings.rd_kafka_assign(@native_kafka, tpl)
+        if response != 0
+          raise Rdkafka::RdkafkaError.new(response, "Error assigning '#{list.to_h}'")
+        end
+      ensure
+        Rdkafka::Bindings.rd_kafka_topic_partition_list_destroy(tpl)
       end
     end
 
@@ -150,19 +164,23 @@ module Rdkafka
     #
     # @return [TopicPartitionList]
     def assignment
-      tpl_ptrptr = FFI::MemoryPointer.new(:pointer)
-      response = Rdkafka::Bindings.rd_kafka_assignment(@native_kafka, tpl_ptrptr)
+      ptr = FFI::MemoryPointer.new(:pointer)
+      response = Rdkafka::Bindings.rd_kafka_assignment(@native_kafka, ptr)
       if response != 0
         raise Rdkafka::RdkafkaError.new(response)
       end
 
-      tpl_ptr = tpl_ptrptr.read_pointer
+      tpl = ptr.read_pointer
 
-      begin
-        Rdkafka::Consumer::TopicPartitionList.from_native_tpl(tpl_ptr)
-      ensure
-        Rdkafka::Bindings.rd_kafka_topic_partition_list_destroy(tpl_ptr)
+      if !tpl.null?
+        begin
+          Rdkafka::Consumer::TopicPartitionList.from_native_tpl(tpl)
+        ensure
+          Rdkafka::Bindings.rd_kafka_topic_partition_list_destroy tpl
+        end
       end
+    ensure
+      ptr.free
     end
 
     # Return the current committed offset per partition for this consumer group.
@@ -180,12 +198,18 @@ module Rdkafka
       elsif !list.is_a?(TopicPartitionList)
         raise TypeError.new("list has to be nil or a TopicPartitionList")
       end
+
       tpl = list.to_native_tpl
-      response = Rdkafka::Bindings.rd_kafka_committed(@native_kafka, tpl, timeout_ms)
-      if response != 0
-        raise Rdkafka::RdkafkaError.new(response)
+
+      begin
+        response = Rdkafka::Bindings.rd_kafka_committed(@native_kafka, tpl, timeout_ms)
+        if response != 0
+          raise Rdkafka::RdkafkaError.new(response)
+        end
+        TopicPartitionList.from_native_tpl(tpl)
+      ensure
+        Rdkafka::Bindings.rd_kafka_topic_partition_list_destroy(tpl)
       end
-      TopicPartitionList.from_native_tpl(tpl)
     end
 
     # Query broker for low (oldest/beginning) and high (newest/end) offsets for a partition.
@@ -207,13 +231,16 @@ module Rdkafka
         partition,
         low,
         high,
-        timeout_ms
+        timeout_ms,
       )
       if response != 0
         raise Rdkafka::RdkafkaError.new(response, "Error querying watermark offsets for partition #{partition} of #{topic}")
       end
 
       return low.read_array_of_uint64(1).first, high.read_array_of_uint64(1).first
+    ensure
+      low.free
+      high.free
     end
 
     # Calculate the consumer lag per partition for the provided topic partition list.
@@ -229,6 +256,7 @@ module Rdkafka
     # @return [Hash<String, Hash<Integer, Integer>>] A hash containing all topics with the lag per partition
     def lag(topic_partition_list, watermark_timeout_ms=100)
       out = {}
+
       topic_partition_list.to_h.each do |topic, partitions|
         # Query high watermarks for this topic's partitions
         # and compare to the offset in the list.
@@ -344,14 +372,20 @@ module Rdkafka
       if !list.nil? && !list.is_a?(TopicPartitionList)
         raise TypeError.new("list has to be nil or a TopicPartitionList")
       end
+
       tpl = if list
               list.to_native_tpl
             else
               nil
             end
-      response = Rdkafka::Bindings.rd_kafka_commit(@native_kafka, tpl, async)
-      if response != 0
-        raise Rdkafka::RdkafkaError.new(response)
+
+      begin
+        response = Rdkafka::Bindings.rd_kafka_commit(@native_kafka, tpl, async)
+        if response != 0
+          raise Rdkafka::RdkafkaError.new(response)
+        end
+      ensure
+        Rdkafka::Bindings.rd_kafka_topic_partition_list_destroy(tpl) if tpl
       end
     end
 
@@ -363,6 +397,8 @@ module Rdkafka
     #
     # @return [Message, nil] A message or nil if there was no new message within the timeout
     def poll(timeout_ms)
+      return if @closed
+
       message_ptr = Rdkafka::Bindings.rd_kafka_consumer_poll(@native_kafka, timeout_ms)
       if message_ptr.null?
         nil

--- a/lib/rdkafka/consumer.rb
+++ b/lib/rdkafka/consumer.rb
@@ -373,11 +373,7 @@ module Rdkafka
         raise TypeError.new("list has to be nil or a TopicPartitionList")
       end
 
-      tpl = if list
-              list.to_native_tpl
-            else
-              nil
-            end
+      tpl = list ? list.to_native_tpl : nil
 
       begin
         response = Rdkafka::Bindings.rd_kafka_commit(@native_kafka, tpl, async)

--- a/lib/rdkafka/consumer/headers.rb
+++ b/lib/rdkafka/consumer/headers.rb
@@ -43,7 +43,6 @@ module Rdkafka
           end
 
           name_ptr = name_ptrptr.read_pointer
-
           name = name_ptr.respond_to?(:read_string_to_null) ? name_ptr.read_string_to_null : name_ptr.read_string
 
           size = size_ptr[:value]
@@ -58,10 +57,6 @@ module Rdkafka
         end
 
         headers
-      ensure
-        headers_ptr.free
-        name_ptr.free
-        value_ptr.free
       end
     end
   end

--- a/lib/rdkafka/consumer/headers.rb
+++ b/lib/rdkafka/consumer/headers.rb
@@ -19,7 +19,7 @@ module Rdkafka
           raise Rdkafka::RdkafkaError.new(err, "Error reading message headers")
         end
 
-        headers_ptr = headers_ptrptr.read(:pointer).tap { |it| it.autorelease = false }
+        headers_ptr = headers_ptrptr.read_pointer
 
         name_ptrptr = FFI::MemoryPointer.new(:pointer)
         value_ptrptr = FFI::MemoryPointer.new(:pointer)
@@ -42,12 +42,15 @@ module Rdkafka
             raise Rdkafka::RdkafkaError.new(err, "Error reading a message header at index #{idx}")
           end
 
-          name = name_ptrptr.read(:pointer).tap { |it| it.autorelease = false }
-          name = name.read_string_to_null
+          name_ptr = name_ptrptr.read_pointer
+
+          name = name_ptr.respond_to?(:read_string_to_null) ? name_ptr.read_string_to_null : name_ptr.read_string
 
           size = size_ptr[:value]
-          value = value_ptrptr.read(:pointer).tap { |it| it.autorelease = false }
-          value = value.read_string(size)
+
+          value_ptr = value_ptrptr.read_pointer
+
+          value = value_ptr.read_string(size)
 
           headers[name.to_sym] = value
 
@@ -55,6 +58,10 @@ module Rdkafka
         end
 
         headers
+      ensure
+        headers_ptr.free
+        name_ptr.free
+        value_ptr.free
       end
     end
   end

--- a/lib/rdkafka/consumer/topic_partition_list.rb
+++ b/lib/rdkafka/consumer/topic_partition_list.rb
@@ -128,7 +128,7 @@ module Rdkafka
       # @return [FFI::AutoPointer]
       # @private
       def to_native_tpl
-        tpl = TopicPartitionList.new_native_tpl(count)
+        tpl = Rdkafka::Bindings.rd_kafka_topic_partition_list_new(count)
 
         @data.each do |topic, partitions|
           if partitions
@@ -138,6 +138,7 @@ module Rdkafka
                 topic,
                 p.partition
               )
+
               if p.offset
                 Rdkafka::Bindings.rd_kafka_topic_partition_list_set_offset(
                   tpl,
@@ -157,16 +158,6 @@ module Rdkafka
         end
 
         tpl
-      end
-
-      # Creates a new native tpl and wraps it into FFI::AutoPointer which in turn calls
-      # `rd_kafka_topic_partition_list_destroy` when a pointer will be cleaned by GC
-      #
-      # @param count [Integer] an initial capacity of partitions list
-      # @return [FFI::AutoPointer]
-      # @private
-      def self.new_native_tpl(count)
-        Rdkafka::Bindings.rd_kafka_topic_partition_list_new(count)
       end
     end
   end

--- a/lib/rdkafka/consumer/topic_partition_list.rb
+++ b/lib/rdkafka/consumer/topic_partition_list.rb
@@ -166,8 +166,7 @@ module Rdkafka
       # @return [FFI::AutoPointer]
       # @private
       def self.new_native_tpl(count)
-        tpl = Rdkafka::Bindings.rd_kafka_topic_partition_list_new(count)
-        FFI::AutoPointer.new(tpl, Rdkafka::Bindings.method(:rd_kafka_topic_partition_list_destroy))
+        Rdkafka::Bindings.rd_kafka_topic_partition_list_new(count)
       end
     end
   end

--- a/lib/rdkafka/consumer/topic_partition_list.rb
+++ b/lib/rdkafka/consumer/topic_partition_list.rb
@@ -125,7 +125,7 @@ module Rdkafka
       #
       # The pointer will be cleaned by `rd_kafka_topic_partition_list_destroy` when GC releases it.
       #
-      # @return [FFI::AutoPointer]
+      # @return [FFI::Pointer]
       # @private
       def to_native_tpl
         tpl = Rdkafka::Bindings.rd_kafka_topic_partition_list_new(count)

--- a/lib/rdkafka/error.rb
+++ b/lib/rdkafka/error.rb
@@ -39,6 +39,11 @@ module Rdkafka
     def is_partition_eof?
       code == :partition_eof
     end
+
+    # Error comparison
+    def ==(another_error)
+       another_error.is_a?(self.class) && (self.to_s == another_error.to_s)
+    end
   end
 
   # Error with topic partition list returned by the underlying rdkafka library.

--- a/lib/rdkafka/producer.rb
+++ b/lib/rdkafka/producer.rb
@@ -41,6 +41,7 @@ module Rdkafka
       @closing = true
       # Wait for the polling thread to finish up
       @polling_thread.join
+      @native_kafka.free
     end
 
     # Produces a message to a Kafka topic. The message is added to rdkafka's queue, call {DeliveryHandle#wait wait} on the returned delivery handle to make sure it is delivered.

--- a/lib/rdkafka/producer.rb
+++ b/lib/rdkafka/producer.rb
@@ -37,11 +37,14 @@ module Rdkafka
 
     # Close this producer and wait for the internal poll queue to empty.
     def close
+      return if @closed
+
       # Indicate to polling thread that we're closing
       @closing = true
       # Wait for the polling thread to finish up
       @polling_thread.join
       Rdkafka::Bindings.rd_kafka_destroy(@native_kafka)
+      @closed = true
     end
 
     # Produces a message to a Kafka topic. The message is added to rdkafka's queue, call {DeliveryHandle#wait wait} on the returned delivery handle to make sure it is delivered.

--- a/lib/rdkafka/producer.rb
+++ b/lib/rdkafka/producer.rb
@@ -41,7 +41,7 @@ module Rdkafka
       @closing = true
       # Wait for the polling thread to finish up
       @polling_thread.join
-      @native_kafka.free
+      Rdkafka::Bindings.rd_kafka_destroy(@native_kafka)
     end
 
     # Produces a message to a Kafka topic. The message is added to rdkafka's queue, call {DeliveryHandle#wait wait} on the returned delivery handle to make sure it is delivered.

--- a/spec/rdkafka/bindings_spec.rb
+++ b/spec/rdkafka/bindings_spec.rb
@@ -7,12 +7,12 @@ describe Rdkafka::Bindings do
 
   describe ".lib_extension" do
     it "should know the lib extension for darwin" do
-      expect(Gem::Platform.local).to receive(:os).and_return("darwin-aaa")
+      stub_const('RbConfig::CONFIG', 'host_os' =>'darwin')
       expect(Rdkafka::Bindings.lib_extension).to eq "dylib"
     end
 
     it "should know the lib extension for linux" do
-      expect(Gem::Platform.local).to receive(:os).and_return("linux")
+      stub_const('RbConfig::CONFIG', 'host_os' =>'linux')
       expect(Rdkafka::Bindings.lib_extension).to eq "so"
     end
   end

--- a/spec/rdkafka/config_spec.rb
+++ b/spec/rdkafka/config_spec.rb
@@ -50,7 +50,9 @@ describe Rdkafka::Config do
     end
 
     it "should create a consumer with valid config" do
-      expect(rdkafka_config.consumer).to be_a Rdkafka::Consumer
+      consumer = rdkafka_config.consumer
+      expect(consumer).to be_a Rdkafka::Consumer
+      consumer.close
     end
 
     it "should raise an error when creating a consumer with invalid config" do
@@ -76,7 +78,9 @@ describe Rdkafka::Config do
     end
 
     it "should create a producer with valid config" do
-      expect(rdkafka_config.producer).to be_a Rdkafka::Producer
+      producer = rdkafka_config.producer
+      expect(producer).to be_a Rdkafka::Producer
+      producer.close
     end
 
     it "should raise an error when creating a producer with invalid config" do

--- a/spec/rdkafka/consumer/message_spec.rb
+++ b/spec/rdkafka/consumer/message_spec.rb
@@ -1,7 +1,8 @@
 require "spec_helper"
 
 describe Rdkafka::Consumer::Message do
-  let(:native_topic) { new_native_topic }
+  let(:native_client) { new_native_client }
+  let(:native_topic) { new_native_topic(native_client: native_client) }
   let(:payload) { nil }
   let(:key) { nil }
   let(:native_message) do
@@ -22,6 +23,10 @@ describe Rdkafka::Consumer::Message do
         message[:key_len] = key.bytesize
       end
     end
+  end
+
+  after(:each) do
+    Rdkafka::Bindings.rd_kafka_destroy(native_client)
   end
 
   subject { Rdkafka::Consumer::Message.new(native_message) }

--- a/spec/rdkafka/consumer_spec.rb
+++ b/spec/rdkafka/consumer_spec.rb
@@ -207,8 +207,6 @@ describe Rdkafka::Consumer do
         expect(records&.payload).to eq "payload c"
         records = consumer.poll(timeout)
         expect(records).to be_nil
-
-        consumer.commit
       end
     end
   end

--- a/spec/rdkafka/consumer_spec.rb
+++ b/spec/rdkafka/consumer_spec.rb
@@ -313,9 +313,9 @@ describe Rdkafka::Consumer do
       }.to raise_error TypeError
     end
 
-    context "with a commited consumer" do
+    context "with a committed consumer" do
       before :all do
-        # Make sure there are some message
+        # Make sure there are some messages.
         handles = []
         producer = rdkafka_config.producer
         10.times do
@@ -329,6 +329,7 @@ describe Rdkafka::Consumer do
           end
         end
         handles.each(&:wait)
+        producer.close
       end
 
       before do
@@ -389,20 +390,26 @@ describe Rdkafka::Consumer do
 
       describe "#store_offset" do
         before do
+          config = {}
           config[:'enable.auto.offset.store'] = false
           config[:'enable.auto.commit'] = false
-          consumer.subscribe("consume_test_topic")
-          wait_for_assignment(consumer)
+          @new_consumer = rdkafka_config(config).consumer
+          @new_consumer.subscribe("consume_test_topic")
+          wait_for_assignment(@new_consumer)
+        end
+
+        after do
+          @new_consumer.close
         end
 
         it "should store the offset for a message" do
-          consumer.store_offset(message)
-          consumer.commit
+          @new_consumer.store_offset(message)
+          @new_consumer.commit
 
           list = Rdkafka::Consumer::TopicPartitionList.new.tap do |list|
             list.add_topic("consume_test_topic", [0, 1, 2])
           end
-          partitions = consumer.committed(list).to_h["consume_test_topic"]
+          partitions = @new_consumer.committed(list).to_h["consume_test_topic"]
           expect(partitions).not_to be_nil
           expect(partitions[message.partition].offset).to eq(message.offset + 1)
         end
@@ -410,7 +417,7 @@ describe Rdkafka::Consumer do
         it "should raise an error with invalid input" do
           allow(message).to receive(:partition).and_return(9999)
           expect {
-            consumer.store_offset(message)
+            @new_consumer.store_offset(message)
           }.to raise_error Rdkafka::RdkafkaError
         end
       end

--- a/spec/rdkafka/error_spec.rb
+++ b/spec/rdkafka/error_spec.rb
@@ -71,15 +71,15 @@ describe Rdkafka::RdkafkaError do
     end
 
     it "should not equal another error with a different error code" do
-      expect(subject).to eq Rdkafka::RdkafkaError.new(20, "Error explanation")
+      expect(subject).not_to eq Rdkafka::RdkafkaError.new(20, "Error explanation")
     end
 
     it "should not equal another error with a different message" do
-      expect(subject).to eq Rdkafka::RdkafkaError.new(10, "Different error explanation")
+      expect(subject).not_to eq Rdkafka::RdkafkaError.new(10, "Different error explanation")
     end
 
     it "should not equal another error with no message" do
-      expect(subject).to eq Rdkafka::RdkafkaError.new(10)
+      expect(subject).not_to eq Rdkafka::RdkafkaError.new(10)
     end
   end
 end

--- a/spec/rdkafka/producer_spec.rb
+++ b/spec/rdkafka/producer_spec.rb
@@ -2,10 +2,13 @@ require "spec_helper"
 
 describe Rdkafka::Producer do
   let(:producer) { rdkafka_config.producer }
+  let(:consumer) { rdkafka_config.consumer }
 
   after do
     # Registry should always end up being empty
     expect(Rdkafka::Producer::DeliveryHandle::REGISTRY).to be_empty
+    producer.close
+    consumer.close
   end
 
   context "delivery callback" do
@@ -82,7 +85,8 @@ describe Rdkafka::Producer do
     # Consume message and verify it's content
     message = wait_for_message(
       topic: "produce_test_topic",
-      delivery_report: report
+      delivery_report: report,
+      consumer: consumer
     )
     expect(message.partition).to eq 1
     expect(message.payload).to eq "payload"
@@ -105,7 +109,8 @@ describe Rdkafka::Producer do
     # Consume message and verify it's content
     message = wait_for_message(
       topic: "produce_test_topic",
-      delivery_report: report
+      delivery_report: report,
+      consumer: consumer
     )
     expect(message.partition).to eq 1
     expect(message.key).to eq "key partition"
@@ -122,7 +127,8 @@ describe Rdkafka::Producer do
     # Consume message and verify it's content
     message = wait_for_message(
       topic: "produce_test_topic",
-      delivery_report: report
+      delivery_report: report,
+      consumer: consumer
     )
 
     expect(message.partition).to eq 1
@@ -154,7 +160,8 @@ describe Rdkafka::Producer do
       # Consume message and verify it's content
       message = wait_for_message(
         topic: "produce_test_topic",
-        delivery_report: report
+        delivery_report: report,
+        consumer: consumer
       )
 
       expect(message.partition).to eq 2
@@ -174,7 +181,8 @@ describe Rdkafka::Producer do
       # Consume message and verify it's content
       message = wait_for_message(
         topic: "produce_test_topic",
-        delivery_report: report
+        delivery_report: report,
+        consumer: consumer
       )
 
       expect(message.partition).to eq 2
@@ -193,7 +201,8 @@ describe Rdkafka::Producer do
     # Consume message and verify it's content
     message = wait_for_message(
       topic: "produce_test_topic",
-      delivery_report: report
+      delivery_report: report,
+      consumer: consumer
     )
 
     expect(message.key).to be_nil
@@ -210,7 +219,8 @@ describe Rdkafka::Producer do
     # Consume message and verify it's content
     message = wait_for_message(
       topic: "produce_test_topic",
-      delivery_report: report
+      delivery_report: report,
+      consumer: consumer
     )
 
     expect(message.key).to eq "key no payload"
@@ -229,7 +239,8 @@ describe Rdkafka::Producer do
     # Consume message and verify it's content
     message = wait_for_message(
       topic: "produce_test_topic",
-      delivery_report: report
+      delivery_report: report,
+      consumer: consumer
     )
 
     expect(message.payload).to eq "payload headers"
@@ -251,7 +262,8 @@ describe Rdkafka::Producer do
     # Consume message and verify it's content
     message = wait_for_message(
       topic: "produce_test_topic",
-      delivery_report: report
+      delivery_report: report,
+      consumer: consumer
     )
 
     expect(message.payload).to eq "payload headers"
@@ -325,7 +337,8 @@ describe Rdkafka::Producer do
     # Consume message and verify it's content
     message = wait_for_message(
       topic: "produce_test_topic",
-      delivery_report: report
+      delivery_report: report,
+      consumer: consumer
     )
     expect(message.partition).to eq 0
     expect(message.payload).to eq "payload-forked"

--- a/spec/rdkafka/producer_spec.rb
+++ b/spec/rdkafka/producer_spec.rb
@@ -307,6 +307,7 @@ describe Rdkafka::Producer do
 
       writer.write(report_json)
       writer.close
+      exit!
     end
 
     writer.close

--- a/spec/rdkafka/producer_spec.rb
+++ b/spec/rdkafka/producer_spec.rb
@@ -48,6 +48,7 @@ describe Rdkafka::Producer do
       handle.wait(max_wait_timeout: 15)
 
       # Callback should have been called
+      sleep 1 # Let lambda#call to finish execution.
       expect(@callback_called).to be true
     end
   end

--- a/spec/rdkafka/producer_spec.rb
+++ b/spec/rdkafka/producer_spec.rb
@@ -30,6 +30,7 @@ describe Rdkafka::Producer do
     it "should call the callback when a message is delivered" do
       @callback_called = false
 
+
       producer.delivery_callback = lambda do |report|
         expect(report).not_to be_nil
         expect(report.partition).to eq 1
@@ -47,8 +48,10 @@ describe Rdkafka::Producer do
       # Wait for it to be delivered
       handle.wait(max_wait_timeout: 15)
 
+      # Join the producer thread.
+      producer.close
+
       # Callback should have been called
-      sleep 1 # Let lambda#call to finish execution.
       expect(@callback_called).to be true
     end
   end

--- a/spec/rdkafka/producer_spec.rb
+++ b/spec/rdkafka/producer_spec.rb
@@ -289,16 +289,9 @@ describe Rdkafka::Producer do
 
     reader, writer = IO.pipe
 
-    producer.close
-    producer.instance_eval {@native_kafka = nil}
-    # For GC'ing @native_kafka references here to avoid finalizer being called in the forked process.
-    GC.start
-    sleep 0.1
-
     fork do
       reader.close
 
-      producer = rdkafka_config.producer
       handle = producer.produce(
         topic:   "produce_test_topic",
         payload: "payload-forked",

--- a/spec/rdkafka/producer_spec.rb
+++ b/spec/rdkafka/producer_spec.rb
@@ -292,6 +292,9 @@ describe Rdkafka::Producer do
     fork do
       reader.close
 
+      # Avoids sharing the socket between processes.
+      producer = rdkafka_config.producer
+
       handle = producer.produce(
         topic:   "produce_test_topic",
         payload: "payload-forked",
@@ -307,7 +310,7 @@ describe Rdkafka::Producer do
 
       writer.write(report_json)
       writer.close
-      exit!
+      producer.close
     end
 
     writer.close

--- a/spec/rdkafka/producer_spec.rb
+++ b/spec/rdkafka/producer_spec.rb
@@ -42,7 +42,7 @@ describe Rdkafka::Producer do
       )
 
       # Wait for it to be delivered
-      handle.wait(max_wait_timeout: 10)
+      handle.wait(max_wait_timeout: 15)
 
       # Callback should have been called
       expect(@callback_called).to be true

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -7,6 +7,12 @@ require "pry"
 require "rspec"
 require "rdkafka"
 
+`docker-compose exec kafka kafka-topics --create --zookeeper zookeeper:2181 --replication-factor 1 --partitions 3 --if-not-exists --topic consume_test_topic`
+`docker-compose exec kafka kafka-topics --create --zookeeper zookeeper:2181 --replication-factor 1 --partitions 3 --if-not-exists --topic empty_test_topic`
+`docker-compose exec kafka kafka-topics --create --zookeeper zookeeper:2181 --replication-factor 1 --partitions 3 --if-not-exists --topic load_test_topic`
+`docker-compose exec kafka kafka-topics --create --zookeeper zookeeper:2181 --replication-factor 1 --partitions 3 --if-not-exists --topic produce_test_topic`
+`docker-compose exec kafka kafka-topics --create --zookeeper zookeeper:2181 --replication-factor 1 --partitions 3 --if-not-exists --topic rake_test_topic`
+
 def rdkafka_config(config_overrides={})
   config = {
     :"api.version.request" => false,

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -32,12 +32,12 @@ def rdkafka_config(config_overrides={})
   Rdkafka::Config.new(config)
 end
 
-def native_client
+def new_native_client
   config = rdkafka_config
   config.send(:native_kafka, config.send(:native_config), :rd_kafka_producer)
 end
 
-def new_native_topic(topic_name="topic_name")
+def new_native_topic(topic_name="topic_name", native_client: )
   Rdkafka::Bindings.rd_kafka_topic_new(
     native_client,
     topic_name,
@@ -46,6 +46,7 @@ def new_native_topic(topic_name="topic_name")
 end
 
 def wait_for_message(topic:, delivery_report:, timeout_in_seconds: 30, consumer: nil)
+  new_consumer = !!consumer
   consumer = rdkafka_config.consumer if consumer.nil?
   consumer.subscribe(topic)
   timeout = Time.now.to_i + timeout_in_seconds
@@ -60,6 +61,8 @@ def wait_for_message(topic:, delivery_report:, timeout_in_seconds: 30, consumer:
       return message
     end
   end
+ensure
+  consumer.close if new_consumer
 end
 
 def wait_for_assignment(consumer)

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -12,6 +12,7 @@ require "rdkafka"
 `docker-compose exec kafka kafka-topics --create --zookeeper zookeeper:2181 --replication-factor 1 --partitions 3 --if-not-exists --topic load_test_topic`
 `docker-compose exec kafka kafka-topics --create --zookeeper zookeeper:2181 --replication-factor 1 --partitions 3 --if-not-exists --topic produce_test_topic`
 `docker-compose exec kafka kafka-topics --create --zookeeper zookeeper:2181 --replication-factor 1 --partitions 3 --if-not-exists --topic rake_test_topic`
+`docker-compose exec kafka kafka-topics --create --zookeeper zookeeper:2181 --replication-factor 1 --partitions 3 --if-not-exists --topic watermarks_test_topic`
 
 def rdkafka_config(config_overrides={})
   config = {


### PR DESCRIPTION
Re-opening #106 here to eliminate the noise due to numerous debugging commits.
I find it easier to trigger travis builds than running the specs locally.

The changes in this PR also include @gaffneyc's changes in #107:

1. Workarounds for the lack of `read_int64`, `read(:pointer)`, `read_string_to_null` in JRuby.
2. Avoid using FFI::AutoPointer objects inside `Rdkafka::Consumer` and explicitly calling `rdkafka_destroy` during close.
3. Avoid calls to `rd_kafka_consumer_poll` after consumer is closed.
4. Use `RbConfig::CONFIG` to check the host OS which is JRuby friendly.
5. Switch to [confluentinc/cp-kafka](https://hub.docker.com/r/confluentinc/cp-kafka) and [confluentinc/cp-zookeeper](https://hub.docker.com/r/confluentinc/cp-zookeeper) licensed with a Apache 2.0 license.
6. Add JRuby to the list of rubies in `.travis.yml`.
7. Remove the usage of `AutoPointer` as it'll lead to closing the socket connections when a child process created using `Kernel#fork` exits which could lead to segmentation faults.

**Findings:**

`E, [2020-01-29T06:17:58.952506 #9416] ERROR -- : rdkafka: [thrd:GroupCoordinator]: 1/1 brokers are down` in specs is trivial as per https://github.com/confluentinc/confluent-kafka-dotnet/issues/1129#issuecomment-561516728 

I'll gladly rebase this PR if you'd wish to merge #107 first.
