### PR TITLE
Make sure producer is closed before it is GCed by Ruby

### DIFF
--- a/lib/rdkafka/producer.rb
+++ b/lib/rdkafka/producer.rb
@@ -11,6 +11,10 @@ module Rdkafka
     def initialize(native_kafka)
       @closing = false
       @native_kafka = native_kafka
+
+      # Makes sure, that the producer gets closed before it gets GCed by Ruby
+      ObjectSpace.define_finalizer(self, proc { close })
+
       # Start thread to poll client for delivery callbacks
       @polling_thread = Thread.new do
         loop do


### PR DESCRIPTION
This PR aims to optimize the problem presented here: https://github.com/appsignal/rdkafka-ruby/issues/15

It makes sure, that before a producer is GCed, it gets closed. I've tested it here: https://github.com/karafka/waterdrop/pull/135

Actions would crash every 3rd build randomly. After we close upon finalization, the problem is no longer present. This is also not a problem for already closed producer as then, nothing happens.

This will ensure, that all the FFI callbacks are handled properly without a segfault.