### PR TITLE
Update producer_spec.rb to allow for Ruby 2.7 missing keyword message

### DIFF
--- a/spec/rdkafka/producer_spec.rb
+++ b/spec/rdkafka/producer_spec.rb
@@ -62,7 +62,7 @@ describe Rdkafka::Producer do
         payload: "payload",
         key:     "key"
      )
-    }.to raise_error ArgumentError, "missing keyword: topic"
+    }.to raise_error ArgumentError, /missing keyword: [\:]?topic/
   end
 
   it "should produce a message" do


### PR DESCRIPTION
Ruby 2.7 introduced non-symbol keyword arguments and changed the error message that is attached to the ArgumentError when a parameter is missing:

In Ruby 2.6 there was no colon before the parameter keyword (i.e. `b`):

```
$ irb
2.6.3 :001 > def m(a:, b:)
2.6.3 :002?>   end
 => :m
2.6.3 :003 > m(a:1)
Traceback (most recent call last):
...
        2: from (irb):3
        1: from (irb):1:in `m'
ArgumentError (missing keyword: b)
```

But Ruby 2.7 there is a colon before the parameter keyword (i.e. `:b`)

```
$ irb
2.7.0 :001 > def m(a:,b:)
2.7.0 :002 > end
 => :m
2.7.0 :003 > m(a:1)
Traceback (most recent call last):
...
        2: from (irb):3
        1: from (irb):1:in `m'
ArgumentError (missing keyword: :b)
```

This change allows the test suite to pass with Ruby 2.7.