### PR TITLE
each_batch

### DIFF
--- a/lib/rdkafka/consumer.rb
+++ b/lib/rdkafka/consumer.rb
@@ -489,7 +489,7 @@ module Rdkafka
         slice << message if message
         if slice.size == max_items || Time.now.to_f >= end_time
           yield slice.dup
-          slice = []
+          slice.clear
         end 
       end 
     end

--- a/lib/rdkafka/consumer.rb
+++ b/lib/rdkafka/consumer.rb
@@ -487,7 +487,7 @@ module Rdkafka
                       end 
         message = poll max_wait_ms
         slice << message if message
-        if slice.size == max_items || Time.now.to_f >= end_time
+        if slice.size == max_items || Time.now.to_f >= end_time - 0.001
           yield slice.dup
           slice.clear
         end 

--- a/lib/rdkafka/consumer.rb
+++ b/lib/rdkafka/consumer.rb
@@ -510,9 +510,9 @@ module Rdkafka
       slice = []
       loop do
         break if @closing
-        start_time = Time.new.to_f
+        start_time = monotonic_now
         end_time = start_time + timeout_ms / 1000.0
-        max_wait = end_time - Time.now.to_f
+        max_wait = end_time - monotonic_now
         max_wait_ms = if max_wait <= 0
                         0   
                       else
@@ -532,11 +532,17 @@ module Rdkafka
           end
         end
         slice << message if message
-        if slice.size == max_items || Time.now.to_f >= end_time - 0.001
+        if slice.size == max_items || monotonic_now >= end_time - 0.001
           yield slice.dup
           slice.clear
         end 
       end 
+    end
+
+    private
+    def monotonic_now
+      # needed because Time.now can go backwards
+      Process.clock_gettime(Process::CLOCK_MONOTONIC)
     end
   end
 end

--- a/lib/rdkafka/consumer.rb
+++ b/lib/rdkafka/consumer.rb
@@ -476,6 +476,7 @@ module Rdkafka
       closed_consumer_check(__method__)
       slice = []
       loop do
+        break if @closing
         start_time = Time.new.to_f
         end_time = start_time + max_latency_ms / 1000.0
         max_wait = end_time - Time.now.to_f
@@ -490,7 +491,6 @@ module Rdkafka
           yield slice.dup
           slice = []
         end 
-        break if @closing
       end 
     end
   end

--- a/spec/rdkafka/consumer_spec.rb
+++ b/spec/rdkafka/consumer_spec.rb
@@ -271,6 +271,14 @@ describe Rdkafka::Consumer do
   describe "#close" do
     it "should close a consumer" do
       consumer.subscribe("consume_test_topic")
+      100.times do |i|
+        report = producer.produce(
+          topic:     "consume_test_topic",
+          payload:   "payload #{i}",
+          key:       "key #{i}",
+          partition: 0
+        ).wait
+      end
       consumer.close
       expect {
         consumer.poll(100)

--- a/spec/rdkafka/consumer_spec.rb
+++ b/spec/rdkafka/consumer_spec.rb
@@ -752,7 +752,7 @@ describe Rdkafka::Consumer do
       yields = []
       timing = []
 
-      consumer.each_batch(max_items: 10, max_latency_ms: 500) do |batch|
+      consumer.each_batch(max_items: 10, timeout_ms: 500) do |batch|
         now = Time.now.to_f
         yields << batch
         timing << now - prev_time
@@ -760,7 +760,7 @@ describe Rdkafka::Consumer do
         break if batch&.size > 0
       end
       expect(timing.last < 0.5).to be true
-      expect(yields.flatten.size).to eq 10
+      expect(yields.last.size).to eq 10
     end
 
     it "should return if the connection is closing" do
@@ -768,7 +768,7 @@ describe Rdkafka::Consumer do
       produce_n 10
       loop_count = 0
       consumer.close
-      consumer.each_batch(max_items: 10, max_latency_ms: 10) do |batch|
+      consumer.each_batch(max_items: 10, timeout_ms: 10) do |batch|
         loop_count = loop_count + 1
         break if loop_count > 10
       end

--- a/spec/rdkafka/consumer_spec.rb
+++ b/spec/rdkafka/consumer_spec.rb
@@ -1,5 +1,6 @@
 require "spec_helper"
 require "ostruct"
+require 'securerandom'
 
 describe Rdkafka::Consumer do
   let(:config) { rdkafka_config }
@@ -679,79 +680,91 @@ describe Rdkafka::Consumer do
   end
 
   describe "#each_batch" do
+    before do
+      @topic = SecureRandom.base64(10).tr('+=/', '')
+    end
+
+    after do
+      @topic = nil
+    end
+
+    def topic_name
+      @topic
+    end
+
     def produce_n(n)
       handles = []
       n.times do |i|
         handles << producer.produce(
-          topic:     "consume_test_topic",
-          payload:   "payload #{i}",
-          key:       "key #{i}",
+          topic:     topic_name,
+          payload:   Time.new.to_f.to_s,
+          key:       i.to_s,
           partition: 0
         )
       end
       handles.each(&:wait)
     end
  
-    it "should yield batches of messages" do
-      consumer.subscribe("consume_test_topic")
+    it "should yield arrays of messages" do
       produce_n 10
+      consumer.subscribe(topic_name)
+      all_yields = []
       consumer.each_batch(max_items: 10) do |batch|
-        expect(batch).to be_instance_of(Array)
-        expect(batch.size).to eq 10
-        break
+        all_yields << batch
+        if batch.any? { |message| message&.key == "9" }
+          break
+        end
       end
+      expect(all_yields.first).to be_instance_of(Array)
+      expect(all_yields.flatten.size).to eq 10
+      expect(all_yields.flatten.first).to be_a Rdkafka::Consumer::Message
+      non_empty_yields = all_yields.reject { |batch| batch.empty? }
+      expect(non_empty_yields.size).to be < 10
     end
 
     it "should yield a partial batch if the timeout is hit with some messages" do
-      pending "not working yet, interference between tests?"
-      consumer.subscribe("consume_test_topic")
+      consumer.subscribe(topic_name)
       produce_n 2
+      all_yields = []
       consumer.each_batch(max_items: 10) do |batch|
-        expect(batch.size).to eq 2
+        all_yields << batch
+        if batch.any? { |message| message&.key == "1" }
+          break
+        end
+      end
+      expect(all_yields.flatten.size).to eq 2
+      expect(all_yields.last.size).to eq 2
+    end
+
+    it "should yield [] if nothing is received before the timeout" do
+      consumer.subscribe(topic_name)
+      consumer.each_batch do |batch|
+        expect(batch).to eq([])
         break
       end
     end
 
-    it "should yield [] if nothing is received before the timeout" do
-      first_yield = "a not nil value, to be replaced by nil"
-      thread = Thread.new do
-        consumer.subscribe("consume_test_topic")
-        consumer.each_batch(max_items: 10, max_latency_ms: 1) do |batch|
-          first_yield = batch
-          break
-        end
-      end
-      thread.join(0.1)
-      thread.kill
-      expect(first_yield).to eq([])
-    end
-
     it "should yield sooner than the timeout latency if batch size is reached" do
-      pending "not working yet, time_done is nil, is each_batch reached?"
-      first_yield = []
-      time_start = nil
-      time_done = nil
-      consumer.subscribe("consume_test_topic")
-      thread = Thread.new do
-        consumer.subscribe("consume_test_topic")
-        time_start = Time.new.to_f
-        consumer.each_batch(max_items: 10, max_latency_ms: 2000) do |batch|
-          first_yield = batch
-          time_done = Time.new.to_f
-          break
-        end
+      consumer.subscribe(topic_name)
+      produce_n 100
+
+      prev_time = Time.new.to_f
+      yields = []
+      timing = []
+
+      consumer.each_batch(max_items: 10, max_latency_ms: 500) do |batch|
+        now = Time.now.to_f
+        yields << batch
+        timing << now - prev_time
+        prev_time = now
+        break if batch&.size > 0
       end
-      produce_n 10
-      thread.join(3)
-      thread.kill
-      expect(time_start).to_not be_nil
-      expect(time_done).to_not be_nil
-      expect(time_done - time_start).to be_less_than 0.3
-      expect(first_yield.size).to eq 10
+      expect(timing.last < 0.5).to be true
+      expect(yields.flatten.size).to eq 10
     end
 
     it "should return if the connection is closing" do
-      consumer.subscribe("consume_test_topic")
+      consumer.subscribe(topic_name)
       produce_n 10
       loop_count = 0
       consumer.close

--- a/spec/rdkafka/consumer_spec.rb
+++ b/spec/rdkafka/consumer_spec.rb
@@ -706,16 +706,16 @@ describe Rdkafka::Consumer do
     end
 
     it "retrieves messages produced into a topic" do
-      # This is the only each_batch test that actually produces
-      # real messages into a topic in the real kafka of the container.
+      # This is the only each_batch test that actually produces real messages
+      # into a topic in the real kafka of the container.
       #
-      # The other tests stub 'poll' which makes them faster and
-      # more reliable, but it makes sense to keep a single test
-      # with a fully integrated flow. This will help to catch changes
-      # in the behavior of 'poll', libdrkafka, or Kafka.
+      # The other tests stub 'poll' which makes them faster and more reliable,
+      # but it makes sense to keep a single test with a fully integrated flow.
+      # This will help to catch breaking changes in the behavior of 'poll',
+      # libdrkafka, or Kafka.
       #
-      # I'm thinking of this as an integration test and the subsequent
-      # specs as unit tests.
+      # This is, in effect, an integration test and the subsequent specs are
+      # unit tests.
       consumer.subscribe(topic_name)
       produce_n 42
       all_yields = []

--- a/spec/rdkafka/consumer_spec.rb
+++ b/spec/rdkafka/consumer_spec.rb
@@ -714,13 +714,10 @@ describe Rdkafka::Consumer do
         .and_return(double("Rdkafka::Consumer::Message"))
       consumer.each_batch(max_items: 10) do |batch|
         all_yields << batch
-        if batch.any? { |message| message&.key == "9" }
-          break
-        end
+        break if all_yields.flatten.size >= 10
       end
       expect(all_yields.first).to be_instance_of(Array)
       expect(all_yields.flatten.size).to eq 10
-      expect(all_yields.flatten.first).to be_a Rdkafka::Consumer::Message
       non_empty_yields = all_yields.reject { |batch| batch.empty? }
       expect(non_empty_yields.size).to be < 10
     end
@@ -742,6 +739,7 @@ describe Rdkafka::Consumer do
         end
       end
       expect(all_yields.flatten.size).to eq 2
+      expect(all_yields.flatten.first).to be_a Rdkafka::Consumer::Message
     end
 
     it "should yield [] if nothing is received before the timeout" do


### PR DESCRIPTION
This PR provides `each_batch`, a method that allows an Rdkafka consumer to receive messages in batches while having control over the maximum size and maximum latencies of the batches.

The intent is to make it easier for users of the library to handle messages in bulk without blocking for unknown amounts of time. Consumers could implement that today using `poll`, since that's how this was implemented, but that implementation is error prone and would only rarely be specific to the business logic of the consumer.

The scope of this emerged in discussion with @thijsc  in the comments of https://github.com/appsignal/rdkafka-ruby/issues/112