### PR TITLE
Don't enable SimpleCov in CI

### DIFF
--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,6 +1,8 @@
-require "simplecov"
-SimpleCov.start do
-  add_filter "/spec/"
+unless ENV["CI"] == "true"
+  require "simplecov"
+  SimpleCov.start do
+    add_filter "/spec/"
+  end
 end
 
 require "pry"


### PR DESCRIPTION
While working on #123, a number of my builds segfaulted and failed during their runs under Travis ([example 1](https://travis-ci.org/github/appsignal/rdkafka-ruby/jobs/705049099)).  I investigated and noticed that segfaults appear to occur sporadically in other builds that did **not** contain my code: [example2](https://travis-ci.org/github/appsignal/rdkafka-ruby/jobs/703628919), [example 3](https://travis-ci.org/github/appsignal/rdkafka-ruby/jobs/703626573).

I have been unable to reproduce the segfaults locally under any of the versions of Ruby we test with. 😞 

Per google searches, [SimpleCov](https://github.com/colszowka/simplecov) seems to be anecdotally related to segmentation faults experienced running builds in CI, so this PR checks for a well-known environment variable `CI` (supported under both [Travis](https://docs.travis-ci.com/user/environment-variables/#default-environment-variables) and [CircleCI](https://circleci.com/docs/2.0/env-vars/#built-in-environment-variables)) and doesn't enable SimpleCov if present.

If this does not solve the issue, we may need to use something like [travis-codedump](https://github.com/springmeyer/travis-coredump) to diagnose the segfaults.

