### PR TITLE
Raise an exception if @native_kafka is nil

### DIFF
--- a/lib/rdkafka/consumer.rb
+++ b/lib/rdkafka/consumer.rb
@@ -36,6 +36,8 @@ module Rdkafka
     #
     # @return [nil]
     def subscribe(*topics)
+      raise "Illegal call to #subscribe after closing the consumer" if @native_kafka.nil?
+
       # Create topic partition list with topics and no partition set
       tpl = Rdkafka::Bindings.rd_kafka_topic_partition_list_new(topics.length)
 
@@ -58,6 +60,8 @@ module Rdkafka
     #
     # @return [nil]
     def unsubscribe
+      raise "Illegal call to #unsubscribe after closing the consumer" if @native_kafka.nil?
+
       response = Rdkafka::Bindings.rd_kafka_unsubscribe(@native_kafka)
       if response != 0
         raise Rdkafka::RdkafkaError.new(response)
@@ -72,6 +76,8 @@ module Rdkafka
     #
     # @return [nil]
     def pause(list)
+      raise "Illegal call to #pause after closing the consumer" if @native_kafka.nil?
+
       unless list.is_a?(TopicPartitionList)
         raise TypeError.new("list has to be a TopicPartitionList")
       end
@@ -98,6 +104,8 @@ module Rdkafka
     #
     # @return [nil]
     def resume(list)
+      raise "Illegal call to #resume after closing the consumer" if @native_kafka.nil?
+
       unless list.is_a?(TopicPartitionList)
         raise TypeError.new("list has to be a TopicPartitionList")
       end
@@ -120,6 +128,8 @@ module Rdkafka
     #
     # @return [TopicPartitionList]
     def subscription
+      raise "Illegal call to #subscription after closing the consumer" if @native_kafka.nil?
+
       ptr = FFI::MemoryPointer.new(:pointer)
       response = Rdkafka::Bindings.rd_kafka_subscription(@native_kafka, ptr)
 
@@ -142,6 +152,8 @@ module Rdkafka
     #
     # @raise [RdkafkaError] When assigning fails
     def assign(list)
+      raise "Illegal call to #assign after closing the consumer" if @native_kafka.nil?
+
       unless list.is_a?(TopicPartitionList)
         raise TypeError.new("list has to be a TopicPartitionList")
       end
@@ -164,6 +176,8 @@ module Rdkafka
     #
     # @return [TopicPartitionList]
     def assignment
+      raise "Illegal call to #assignment after closing the consumer" if @native_kafka.nil?
+
       ptr = FFI::MemoryPointer.new(:pointer)
       response = Rdkafka::Bindings.rd_kafka_assignment(@native_kafka, ptr)
       if response != 0
@@ -193,6 +207,8 @@ module Rdkafka
     #
     # @return [TopicPartitionList]
     def committed(list=nil, timeout_ms=1200)
+      raise "Illegal call to #committed after closing the consumer" if @native_kafka.nil?
+
       if list.nil?
         list = assignment
       elsif !list.is_a?(TopicPartitionList)
@@ -222,6 +238,8 @@ module Rdkafka
     #
     # @return [Integer] The low and high watermark
     def query_watermark_offsets(topic, partition, timeout_ms=200)
+      raise "Illegal call to #query_watermark_offsets after closing the consumer" if @native_kafka.nil?
+
       low = FFI::MemoryPointer.new(:int64, 1)
       high = FFI::MemoryPointer.new(:int64, 1)
 
@@ -279,6 +297,7 @@ module Rdkafka
     #
     # @return [String, nil]
     def cluster_id
+      raise "Illegal call to #cluster_id after closing the consumer" if @native_kafka.nil?
       Rdkafka::Bindings.rd_kafka_clusterid(@native_kafka)
     end
 
@@ -288,6 +307,7 @@ module Rdkafka
     #
     # @return [String, nil]
     def member_id
+      raise "Illegal call to #member_id after closing the consumer" if @native_kafka.nil?
       Rdkafka::Bindings.rd_kafka_memberid(@native_kafka)
     end
 
@@ -301,6 +321,8 @@ module Rdkafka
     #
     # @return [nil]
     def store_offset(message)
+      raise "Illegal call to #store_offset after closing the consumer" if @native_kafka.nil?
+
       # rd_kafka_offset_store is one of the few calls that does not support
       # a string as the topic, so create a native topic for it.
       native_topic = Rdkafka::Bindings.rd_kafka_topic_new(
@@ -331,6 +353,8 @@ module Rdkafka
     #
     # @return [nil]
     def seek(message)
+      raise "Illegal call to #seek after closing the consumer" if @native_kafka.nil?
+
       # rd_kafka_offset_store is one of the few calls that does not support
       # a string as the topic, so create a native topic for it.
       native_topic = Rdkafka::Bindings.rd_kafka_topic_new(
@@ -369,6 +393,8 @@ module Rdkafka
     #
     # @return [nil]
     def commit(list=nil, async=false)
+      raise "Illegal call to #commit after closing the consumer" if @native_kafka.nil?
+
       if !list.nil? && !list.is_a?(TopicPartitionList)
         raise TypeError.new("list has to be nil or a TopicPartitionList")
       end
@@ -393,7 +419,7 @@ module Rdkafka
     #
     # @return [Message, nil] A message or nil if there was no new message within the timeout
     def poll(timeout_ms)
-      return unless @native_kafka
+      raise "Illegal call to #poll after closing the consumer" if @native_kafka.nil?
 
       message_ptr = Rdkafka::Bindings.rd_kafka_consumer_poll(@native_kafka, timeout_ms)
       if message_ptr.null?

--- a/lib/rdkafka/consumer.rb
+++ b/lib/rdkafka/consumer.rb
@@ -51,7 +51,7 @@ module Rdkafka
         raise Rdkafka::RdkafkaError.new(response, "Error subscribing to '#{topics.join(', ')}'")
       end
     ensure
-      Rdkafka::Bindings.rd_kafka_topic_partition_list_destroy(tpl) if tpl
+      Rdkafka::Bindings.rd_kafka_topic_partition_list_destroy(tpl) unless tpl.nil?
     end
 
     # Unsubscribe from all subscribed topics.

--- a/lib/rdkafka/consumer.rb
+++ b/lib/rdkafka/consumer.rb
@@ -468,14 +468,8 @@ module Rdkafka
       end
     end
 
-    class ClosedConsumerError < RuntimeError
-      def initialize(method)
-        super("Illegal call to #{method.to_s} on a closed consumer")
-      end
-    end
-
     def closed_consumer_check(method)
-      raise ClosedConsumerError.new(method) if @native_kafka.nil?
+      raise Rdkafka::ClosedConsumerError.new(method) if @native_kafka.nil?
     end
   end
 end

--- a/lib/rdkafka/error.rb
+++ b/lib/rdkafka/error.rb
@@ -1,6 +1,9 @@
 module Rdkafka
+  # Base error class.
+  class BaseError < RuntimeError; end
+
   # Error returned by the underlying rdkafka library.
-  class RdkafkaError < RuntimeError
+  class RdkafkaError < BaseError
     # The underlying raw error response
     # @return [Integer]
     attr_reader :rdkafka_response
@@ -64,6 +67,20 @@ module Rdkafka
     def initialize(response, topic_partition_list, message_prefix=nil)
       super(response, message_prefix)
       @topic_partition_list = topic_partition_list
+    end
+  end
+
+  # Error class for public consumer method calls on a closed consumer.
+  class ClosedConsumerError < BaseError
+    def initialize(method)
+      super("Illegal call to #{method.to_s} on a closed consumer")
+    end
+  end
+
+  # Error class for public producer method calls on a closed producer.
+  class ClosedProducerError < BaseError
+    def initialize(method)
+      super("Illegal call to #{method.to_s} on a closed producer")
     end
   end
 end

--- a/lib/rdkafka/producer.rb
+++ b/lib/rdkafka/producer.rb
@@ -59,6 +59,7 @@ module Rdkafka
     # @return partition count [Integer,nil]
     #
     def partition_count(topic)
+      raise "Illegal call to #partition_count after closing the producer" if @native_kafka.nil?
       Rdkafka::Metadata.new(@native_kafka, topic).topics&.first[:partition_count]
     end
 
@@ -78,6 +79,8 @@ module Rdkafka
     #
     # @return [DeliveryHandle] Delivery handle that can be used to wait for the result of producing this message
     def produce(topic:, payload: nil, key: nil, partition: nil, partition_key: nil, timestamp: nil, headers: nil)
+      raise "Illegal call to #produce after closing the producer" if @native_kafka.nil?
+
       # Start by checking and converting the input
 
       # Get payload length

--- a/lib/rdkafka/producer.rb
+++ b/lib/rdkafka/producer.rb
@@ -171,14 +171,8 @@ module Rdkafka
       @delivery_callback.call(delivery_handle) if @delivery_callback
     end
 
-    class ClosedProducerError < RuntimeError
-      def initialize(method)
-        super("Illegal call to #{method.to_s} on a closed producer")
-      end
-    end
-
     def closed_producer_check(method)
-      raise ClosedProducerError.new(method) if @native_kafka.nil?
+      raise Rdkafka::ClosedProducerError.new(method) if @native_kafka.nil?
     end
   end
 end

--- a/spec/rdkafka/consumer_spec.rb
+++ b/spec/rdkafka/consumer_spec.rb
@@ -734,15 +734,16 @@ describe Rdkafka::Consumer do
       consumer.close
     end
 
+    # Affected methods and a non-invalid set of parameters for the method
     {
-        :subscribe       => [ nil ],
-        :unsubscribe     => nil,
-        :pause           => [ nil ],
-        :resume          => [ nil ],
-        :subscription    => nil,
-        :assign          => [ nil ],
-        :assignment      => nil,
-        :committed       => [],
+        :subscribe               => [ nil ],
+        :unsubscribe             => nil,
+        :pause                   => [ nil ],
+        :resume                  => [ nil ],
+        :subscription            => nil,
+        :assign                  => [ nil ],
+        :assignment              => nil,
+        :committed               => [],
         :query_watermark_offsets => [ nil, nil ],
     }.each do |method, args|
       it "raises an exception if #{method} is called" do

--- a/spec/rdkafka/consumer_spec.rb
+++ b/spec/rdkafka/consumer_spec.rb
@@ -663,8 +663,6 @@ describe Rdkafka::Consumer do
       # Check the first 10 messages. Then close the consumer, which
       # should break the each loop.
       consumer.each_with_index do |message, i|
-        puts message
-        puts i
         expect(message).to be_a Rdkafka::Consumer::Message
         break if i == 10
       end
@@ -747,7 +745,6 @@ describe Rdkafka::Consumer do
         :query_watermark_offsets => [ nil, nil ],
     }.each do |method, args|
       it "raises an exception if #{method} is called" do
-        puts method
         expect {
           if args.nil?
             consumer.public_send(method)

--- a/spec/rdkafka/consumer_spec.rb
+++ b/spec/rdkafka/consumer_spec.rb
@@ -727,7 +727,7 @@ describe Rdkafka::Consumer do
     end
   end
 
-  context "methods that should not be called after a producer has been closed" do
+  context "methods that should not be called after a consumer has been closed" do
     before do
       consumer.close
     end

--- a/spec/rdkafka/consumer_spec.rb
+++ b/spec/rdkafka/consumer_spec.rb
@@ -274,7 +274,7 @@ describe Rdkafka::Consumer do
       consumer.close
       expect {
         consumer.poll(100)
-      }.to raise_error(Rdkafka::Consumer::ClosedConsumerError, /poll/)
+      }.to raise_error(Rdkafka::ClosedConsumerError, /poll/)
     end
   end
 
@@ -751,7 +751,7 @@ describe Rdkafka::Consumer do
           else
             consumer.public_send(method, *args)
           end
-        }.to raise_exception(Rdkafka::Consumer::ClosedConsumerError, /#{method.to_s}/)
+        }.to raise_exception(Rdkafka::ClosedConsumerError, /#{method.to_s}/)
       end
     end
   end

--- a/spec/rdkafka/producer_spec.rb
+++ b/spec/rdkafka/producer_spec.rb
@@ -413,6 +413,7 @@ describe Rdkafka::Producer do
       producer.close
     end
 
+    # Affected methods and a non-invalid set of parameters for the method
     {
         :produce         => { topic: nil },
         :partition_count => nil,

--- a/spec/rdkafka/producer_spec.rb
+++ b/spec/rdkafka/producer_spec.rb
@@ -407,4 +407,21 @@ describe Rdkafka::Producer do
     # Waiting a second time should work
     handle.wait(max_wait_timeout: 5)
   end
+
+  context "methods that should not be called after a producer has been closed" do
+    before do
+      producer.close
+    end
+
+    {
+        :produce         => { topic: nil },
+        :partition_count => nil,
+    }.each do |method, args|
+      it "raises an exception if #{method} is called" do
+        expect {
+          producer.public_send(method, args)
+        }.to raise_exception(Rdkafka::Producer::ClosedProducerError, /#{method.to_s}/)
+      end
+    end
+  end
 end

--- a/spec/rdkafka/producer_spec.rb
+++ b/spec/rdkafka/producer_spec.rb
@@ -420,7 +420,11 @@ describe Rdkafka::Producer do
     }.each do |method, args|
       it "raises an exception if #{method} is called" do
         expect {
-          producer.public_send(method, args)
+          if args.is_a?(Hash)
+            producer.public_send(method, **args)
+          else
+            producer.public_send(method, args)
+          end
         }.to raise_exception(Rdkafka::Producer::ClosedProducerError, /#{method.to_s}/)
       end
     end

--- a/spec/rdkafka/producer_spec.rb
+++ b/spec/rdkafka/producer_spec.rb
@@ -425,7 +425,7 @@ describe Rdkafka::Producer do
           else
             producer.public_send(method, args)
           end
-        }.to raise_exception(Rdkafka::Producer::ClosedProducerError, /#{method.to_s}/)
+        }.to raise_exception(Rdkafka::ClosedProducerError, /#{method.to_s}/)
       end
     end
   end


### PR DESCRIPTION
## The problem

Many methods in the `Producer` and `Consumer` classes are dependent on being able to pass the value of `@native_kafka` instance variable to underlying librdkafka bindings.

This can lead to trouble, however if the `#close` method has been called (which sets `@native_kafka` to nil), and can lead to unrecoverable segfaults.

## The proposed solution

Do a pre-flight check in every method that is dependent on `@native_kafka` being non-nil so that we can raise a proper Ruby exception to the caller instead of facing them with a 1000+ C line backtrace and crash log ([example](https://gist.github.com/geoff2k/d95d54185d4ba556368da4c049ea4026)).

In my opinion, we should strive for gems that *never* allow a ruby developer to see a C stack trace, or more glibly, isnt this:

```
     Rdkafka::Consumer::ClosedConsumerError:
       Illegal call to subscribe on a closed consumer
```

better than this? 😉 

```
-- Control frame information -----------------------------------------------
c:0046 p:---- s:0246 e:000245 CFUNC  :rd_kafka_topic_partition_list_add
c:0045 p:0022 s:0239 e:000238 BLOCK  /Users/geoff2k/src/kafka/rdkafka-ruby/lib/rdkafka/consumer.rb:45 [FINISH]
c:0044 p:---- s:0235 e:000234 CFUNC  :each
c:0043 p:0033 s:0231 e:000230 METHOD /Users/geoff2k/src/kafka/rdkafka-ruby/lib/rdkafka/consumer.rb:44 [FINISH]
....
```