### PR TITLE
Fix a couple of issues in the Metadata class

### DIFF
--- a/lib/rdkafka/metadata.rb
+++ b/lib/rdkafka/metadata.rb
@@ -35,11 +35,11 @@ module Rdkafka
 
       @topics = Array.new(metadata[:topics_count]) do |i|
         topic = TopicMetadata.new(metadata[:topics_metadata] + (i * TopicMetadata.size))
-        Rdkafka::RdkafkaError.new(topic[:rd_kafka_resp_err]) unless topic[:rd_kafka_resp_err].zero?
+        raise Rdkafka::RdkafkaError.new(topic[:rd_kafka_resp_err]) unless topic[:rd_kafka_resp_err].zero?
 
         partitions = Array.new(topic[:partition_count]) do |j|
           partition = PartitionMetadata.new(topic[:partitions_metadata] + (j * PartitionMetadata.size))
-          Rdkafka::RdkafkaError.new(partition[:rd_kafka_resp_err]) unless partition[:rd_kafka_resp_err].zero?
+          raise Rdkafka::RdkafkaError.new(partition[:rd_kafka_resp_err]) unless partition[:rd_kafka_resp_err].zero?
           partition.to_h
         end
         topic.to_h.merge!(partitions: partitions)

--- a/lib/rdkafka/metadata.rb
+++ b/lib/rdkafka/metadata.rb
@@ -9,8 +9,8 @@ module Rdkafka
 
       ptr = FFI::MemoryPointer.new(:pointer)
 
-      # If topic_flag is 1, request info about all topics in cluster.  If topic_flag is 0,
-      # only request info about locally known topics (or a single topic).
+      # If topic_flag is 1, we request info about *all* topics in the cluster.  If topic_flag is 0,
+      # we only request info about locally known topics (or a single topic if one is passed in).
       topic_flag = topic_name.nil? ? 1 : 0
 
       # Retrieve the Metadata

--- a/lib/rdkafka/metadata.rb
+++ b/lib/rdkafka/metadata.rb
@@ -9,14 +9,15 @@ module Rdkafka
 
       ptr = FFI::MemoryPointer.new(:pointer)
 
-      # Retrieve metadata flag is 0/1 for single/multiple topics.
-      topic_flag = topic_name ? 1 : 0
+      # If topic_flag is 1, request info about all topics in cluster.  If topic_flag is 0,
+      # only request info about locally known topics (or a single topic).
+      topic_flag = topic_name.nil? ? 1 : 0
 
       # Retrieve the Metadata
       result = Rdkafka::Bindings.rd_kafka_metadata(native_client, topic_flag, native_topic, ptr, 250)
 
       # Error Handling
-      Rdkafka::RdkafkaError.new(result) unless result.zero?
+      raise Rdkafka::RdkafkaError.new(result) unless result.zero?
 
       metadata_from_native(ptr.read_pointer)
     ensure

--- a/lib/rdkafka/producer.rb
+++ b/lib/rdkafka/producer.rb
@@ -55,7 +55,7 @@ module Rdkafka
     # @return partition count [Integer,nil]
     #
     def partition_count(topic)
-      Rdkafka::Metadata.new(@native_kafka, topic).topics&.select { |x| x[:topic_name] == topic }&.dig(0, :partition_count)
+      Rdkafka::Metadata.new(@native_kafka, topic).topics&.first[:partition_count]
     end
 
     # Produces a message to a Kafka topic. The message is added to rdkafka's queue, call {DeliveryHandle#wait wait} on the returned delivery handle to make sure it is delivered.

--- a/spec/rdkafka/metadata_spec.rb
+++ b/spec/rdkafka/metadata_spec.rb
@@ -1,0 +1,85 @@
+require "spec_helper"
+require "securerandom"
+
+describe Rdkafka::Metadata do
+  let(:config)        { rdkafka_config }
+  let(:native_config) { config.send(:native_config) }
+  let(:native_kafka)  { config.send(:native_kafka, native_config, :rd_kafka_consumer) }
+
+  after do
+    Rdkafka::Bindings.rd_kafka_consumer_close(native_kafka)
+    Rdkafka::Bindings.rd_kafka_destroy(native_kafka)
+  end
+
+  subject { described_class.new(native_kafka, topic_name) }
+
+  context "with a topic" do
+
+    context "with a non-existent topic" do
+      let(:topic_name) { SecureRandom.uuid.to_s }
+
+      it "#brokers" do
+        expect(subject.brokers.length).to eq(1)
+        expect(subject.brokers[0][:broker_id]).to eq(1)
+        expect(subject.brokers[0][:broker_name]).to eq("localhost")
+        expect(subject.brokers[0][:broker_port]).to eq(9092)
+      end
+
+      it "#topics" do
+        expect(subject.topics[0][:partition_count]).to eq(0)
+        expect(subject.topics[0][:partitions]).to eq([])
+        expect(subject.topics[0][:topic_name]).to eq(topic_name)
+      end
+    end
+
+    context "with an existing topic" do
+      let(:topic_name) { "partitioner_test_topic" }
+
+      it "#brokers" do
+        expect(subject.brokers.length).to eq(1)
+        expect(subject.brokers[0][:broker_id]).to eq(1)
+        expect(subject.brokers[0][:broker_name]).to eq("localhost")
+        expect(subject.brokers[0][:broker_port]).to eq(9092)
+      end
+
+      it "#topics" do
+        expect(subject.topics[0][:partition_count]).to eq(25)
+        expect(subject.topics[0][:partitions].length).to eq(25)
+        expect(subject.topics[0][:topic_name]).to eq(topic_name)
+      end
+    end
+  end
+
+  context "without a topic" do
+    let(:topic_name) { nil }
+    let(:test_topics) {
+      %w(consume_test_topic empty_test_topic load_test_topic produce_test_topic rake_test_topic watermarks_test_topic partitioner_test_topic)
+    } # Test topics crated in spec_helper.rb
+
+    it "#brokers" do
+      expect(subject.brokers.length).to eq(1)
+      expect(subject.brokers[0][:broker_id]).to eq(1)
+      expect(subject.brokers[0][:broker_name]).to eq("localhost")
+      expect(subject.brokers[0][:broker_port]).to eq(9092)
+    end
+
+    it "#topics" do
+      result = subject.topics.map { |topic| topic[:topic_name] }
+      expect(result).to include(*test_topics)
+    end
+  end
+
+  context "when a non-zero error code is returned" do
+    let(:topic_name) { SecureRandom.uuid.to_s }
+
+    before do
+      allow(Rdkafka::Bindings).to receive(:rd_kafka_metadata).and_return(-165)
+    end
+
+    it "#brokers" do
+      expect {
+        described_class.new(native_kafka, topic_name)
+      }.to raise_error(Rdkafka::RdkafkaError, /Local: Required feature not supported by broker \(unsupported_feature\)/)
+    end
+  end
+end

--- a/spec/rdkafka/metadata_spec.rb
+++ b/spec/rdkafka/metadata_spec.rb
@@ -13,36 +13,35 @@ describe Rdkafka::Metadata do
 
   subject { described_class.new(native_kafka, topic_name) }
 
-  context "with a topic" do
-
-    context "with a non-existent topic" do
+  context "passing in a topic name" do
+    context "that is non-existent topic" do
       let(:topic_name) { SecureRandom.uuid.to_s }
 
-      it "#brokers" do
+      it "#brokers returns our single broker" do
         expect(subject.brokers.length).to eq(1)
         expect(subject.brokers[0][:broker_id]).to eq(1)
         expect(subject.brokers[0][:broker_name]).to eq("localhost")
         expect(subject.brokers[0][:broker_port]).to eq(9092)
       end
 
-      it "#topics" do
+      it "#topics returns no partitions" do
         expect(subject.topics[0][:partition_count]).to eq(0)
         expect(subject.topics[0][:partitions]).to eq([])
         expect(subject.topics[0][:topic_name]).to eq(topic_name)
       end
     end
 
-    context "with an existing topic" do
+    context "that is one of our test topics" do
       let(:topic_name) { "partitioner_test_topic" }
 
-      it "#brokers" do
+      it "#brokers returns our single broker" do
         expect(subject.brokers.length).to eq(1)
         expect(subject.brokers[0][:broker_id]).to eq(1)
         expect(subject.brokers[0][:broker_name]).to eq("localhost")
         expect(subject.brokers[0][:broker_port]).to eq(9092)
       end
 
-      it "#topics" do
+      it "#topics returns data on our test topic" do
         expect(subject.topics[0][:partition_count]).to eq(25)
         expect(subject.topics[0][:partitions].length).to eq(25)
         expect(subject.topics[0][:topic_name]).to eq(topic_name)
@@ -50,20 +49,20 @@ describe Rdkafka::Metadata do
     end
   end
 
-  context "without a topic" do
+  context "not passing in a topic name" do
     let(:topic_name) { nil }
     let(:test_topics) {
       %w(consume_test_topic empty_test_topic load_test_topic produce_test_topic rake_test_topic watermarks_test_topic partitioner_test_topic)
     } # Test topics crated in spec_helper.rb
 
-    it "#brokers" do
+    it "#brokers returns our single broker" do
       expect(subject.brokers.length).to eq(1)
       expect(subject.brokers[0][:broker_id]).to eq(1)
       expect(subject.brokers[0][:broker_name]).to eq("localhost")
       expect(subject.brokers[0][:broker_port]).to eq(9092)
     end
 
-    it "#topics" do
+    it "#topics returns data about all of our test topics" do
       result = subject.topics.map { |topic| topic[:topic_name] }
       expect(result).to include(*test_topics)
     end
@@ -76,7 +75,7 @@ describe Rdkafka::Metadata do
       allow(Rdkafka::Bindings).to receive(:rd_kafka_metadata).and_return(-165)
     end
 
-    it "#brokers" do
+    it "creating the instance raises an exception" do
       expect {
         described_class.new(native_kafka, topic_name)
       }.to raise_error(Rdkafka::RdkafkaError, /Local: Required feature not supported by broker \(unsupported_feature\)/)

--- a/spec/rdkafka/metadata_spec.rb
+++ b/spec/rdkafka/metadata_spec.rb
@@ -11,28 +11,19 @@ describe Rdkafka::Metadata do
     Rdkafka::Bindings.rd_kafka_destroy(native_kafka)
   end
 
-  subject { described_class.new(native_kafka, topic_name) }
-
   context "passing in a topic name" do
     context "that is non-existent topic" do
       let(:topic_name) { SecureRandom.uuid.to_s }
 
-      it "#brokers returns our single broker" do
-        expect(subject.brokers.length).to eq(1)
-        expect(subject.brokers[0][:broker_id]).to eq(1)
-        expect(subject.brokers[0][:broker_name]).to eq("localhost")
-        expect(subject.brokers[0][:broker_port]).to eq(9092)
-      end
-
-      it "#topics returns no partitions" do
-        expect(subject.topics.length).to eq(1)
-        expect(subject.topics[0][:partition_count]).to eq(0)
-        expect(subject.topics[0][:partitions]).to eq([])
-        expect(subject.topics[0][:topic_name]).to eq(topic_name)
+      it "raises an appropriate exception" do
+        expect {
+          described_class.new(native_kafka, topic_name)
+        }.to raise_exception(Rdkafka::RdkafkaError, "Broker: Leader not available (leader_not_available)")
       end
     end
 
     context "that is one of our test topics" do
+      subject { described_class.new(native_kafka, topic_name) }
       let(:topic_name) { "partitioner_test_topic" }
 
       it "#brokers returns our single broker" do
@@ -52,6 +43,7 @@ describe Rdkafka::Metadata do
   end
 
   context "not passing in a topic name" do
+    subject { described_class.new(native_kafka, topic_name) }
     let(:topic_name) { nil }
     let(:test_topics) {
       %w(consume_test_topic empty_test_topic load_test_topic produce_test_topic rake_test_topic watermarks_test_topic partitioner_test_topic)

--- a/spec/rdkafka/metadata_spec.rb
+++ b/spec/rdkafka/metadata_spec.rb
@@ -25,6 +25,7 @@ describe Rdkafka::Metadata do
       end
 
       it "#topics returns no partitions" do
+        expect(subject.topics.length).to eq(1)
         expect(subject.topics[0][:partition_count]).to eq(0)
         expect(subject.topics[0][:partitions]).to eq([])
         expect(subject.topics[0][:topic_name]).to eq(topic_name)
@@ -42,6 +43,7 @@ describe Rdkafka::Metadata do
       end
 
       it "#topics returns data on our test topic" do
+        expect(subject.topics.length).to eq(1)
         expect(subject.topics[0][:partition_count]).to eq(25)
         expect(subject.topics[0][:partitions].length).to eq(25)
         expect(subject.topics[0][:topic_name]).to eq(topic_name)


### PR DESCRIPTION
## The Problem

I noticed a couple of oddities around the current `Metadata` class:
* It creates a `RdkafkaError` instance on a non-zero return from `rd_kafka_metadata` but doesn't raise it
* It returns Metadata for more than one topic even if a topic name is passed in to its initializer.

The only place we seem to use the Metadata class is in the [`Producer`](https://github.com/appsignal/rdkafka-ruby/blob/main/lib/rdkafka/producer.rb#L58), and it does an unnecessary `select` as it is getting more than one topic back from its request.

## The Solution

Fix the oddities, update the Producer so that it can assume it will only get a single topic's metadata back, and add explicit specs for the `Metadata` class.
