### PR TITLE
Enable zstd compression

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -29,6 +29,7 @@ before_install:
       sudo apt-get install -y libpthread-stubs0-dev && \
       sudo apt-get install -y build-essential && \
       sudo apt-get install -y zlib1g-dev && \
+      sudo apt-get install -y libzstd-dev && \
       sudo apt-get install -y libssl-dev && \
       sudo apt-get install -y libsasl2-dev
     fi

--- a/.travis.yml
+++ b/.travis.yml
@@ -22,19 +22,8 @@ rvm:
 before_install:
   - gem update --system
   - |
-    r_eng="$(ruby -e 'STDOUT.write RUBY_ENGINE')";
-    if [ "$r_eng" == "jruby" ]; then
-      sudo apt-get update && \
-      sudo apt-get install -y git && \
-      sudo apt-get install -y libpthread-stubs0-dev && \
-      sudo apt-get install -y build-essential && \
-      sudo apt-get install -y zlib1g-dev && \
-      sudo apt-get install -y libzstd-dev && \
-      sudo apt-get install -y libssl-dev && \
-      sudo apt-get install -y libsasl2-dev
-    else
-      apt-get update && apt-get install -y git build-essential libpthread-stubs0-dev zlib1g-dev libzstd-dev libssl-dev libsasl2-dev
-    fi
+    sudo apt-get update && \
+    sudo apt-get install -y git build-essential libpthread-stubs0-dev zlib1g-dev libzstd-dev libssl-dev libsasl2-dev
 
 before_script:
   - docker-compose up -d

--- a/.travis.yml
+++ b/.travis.yml
@@ -32,7 +32,7 @@ before_install:
       sudo apt-get install -y libzstd-dev && \
       sudo apt-get install -y libssl-dev && \
       sudo apt-get install -y libsasl2-dev
-    elif
+    else
       apt-get update && apt-get install -y git build-essential libpthread-stubs0-dev zlib1g-dev libzstd-dev libssl-dev libsasl2-dev
     fi
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,5 @@
 language: ruby
-dist: xenial
+dist: bionic
 os: linux
 
 services:

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,6 @@
 language: ruby
-
-sudo: false
+dist: xenial
+os: linux
 
 services:
   - docker
@@ -32,6 +32,8 @@ before_install:
       sudo apt-get install -y libzstd-dev && \
       sudo apt-get install -y libssl-dev && \
       sudo apt-get install -y libsasl2-dev
+    elif
+      apt-get update && apt-get install -y git build-essential libpthread-stubs0-dev zlib1g-dev libzstd-dev libssl-dev libsasl2-dev
     fi
 
 before_script:

--- a/ext/Rakefile
+++ b/ext/Rakefile
@@ -65,7 +65,7 @@ namespace :build do
 
     recipe = MiniPortile.new("librdkafka", version)
     recipe.files << "https://github.com/edenhill/librdkafka/archive/#{ref}.tar.gz"
-    recipe.configure_options = ["--host=#{recipe.host}", "--enable-zstd"]
+    recipe.configure_options = ["--host=#{recipe.host}","--enable-static", "--enable-zstd"]
     recipe.cook
 
     ext = recipe.host.include?("darwin") ? "dylib" : "so"

--- a/ext/Rakefile
+++ b/ext/Rakefile
@@ -65,7 +65,7 @@ namespace :build do
 
     recipe = MiniPortile.new("librdkafka", version)
     recipe.files << "https://github.com/edenhill/librdkafka/archive/#{ref}.tar.gz"
-    recipe.configure_options = ["--host=#{recipe.host}"]
+    recipe.configure_options = ["--host=#{recipe.host}", "--enable-zstd"]
     recipe.cook
 
     ext = recipe.host.include?("darwin") ? "dylib" : "so"

--- a/spec/rdkafka/config_spec.rb
+++ b/spec/rdkafka/config_spec.rb
@@ -90,6 +90,12 @@ describe Rdkafka::Config do
       }.to raise_error(Rdkafka::Config::ConfigError, "No such configuration property: \"invalid.key\"")
     end
 
+    it "should allow configuring compression" do
+      config = Rdkafka::Config.new('compression.codec' => 'zstd')
+      expect(config.producer).to be_a Rdkafka::Producer
+      config.producer.close
+    end
+
     it "should raise an error when client creation fails for a consumer" do
       config = Rdkafka::Config.new(
         "security.protocol" => "SSL",

--- a/spec/rdkafka/config_spec.rb
+++ b/spec/rdkafka/config_spec.rb
@@ -90,7 +90,7 @@ describe Rdkafka::Config do
       }.to raise_error(Rdkafka::Config::ConfigError, "No such configuration property: \"invalid.key\"")
     end
 
-    it "should allow configuring compression" do
+    it "should allow configuring zstd compression" do
       config = Rdkafka::Config.new('compression.codec' => 'zstd')
       expect(config.producer).to be_a Rdkafka::Producer
       config.producer.close


### PR DESCRIPTION
We are using this plugin with Fluentd, and need to enable zstd compression for our log output. This PR works for us, but perhaps needs some additional changes to be compatible with everyone else? Let me know if this is something you would consider merging. 