### PR TITLE
actually raise an error when one occurs while reading metadata

### DIFF
--- a/lib/rdkafka/metadata.rb
+++ b/lib/rdkafka/metadata.rb
@@ -16,7 +16,7 @@ module Rdkafka
       result = Rdkafka::Bindings.rd_kafka_metadata(native_client, topic_flag, native_topic, ptr, 250)
 
       # Error Handling
-      Rdkafka::RdkafkaError.new(result) unless result.zero?
+      raise Rdkafka::RdkafkaError.new(result) unless result.zero?
 
       metadata_from_native(ptr.read_pointer)
     ensure
@@ -34,11 +34,11 @@ module Rdkafka
 
       @topics = Array.new(metadata[:topics_count]) do |i|
         topic = TopicMetadata.new(metadata[:topics_metadata] + (i * TopicMetadata.size))
-        Rdkafka::RdkafkaError.new(topic[:rd_kafka_resp_err]) unless topic[:rd_kafka_resp_err].zero?
+        raise Rdkafka::RdkafkaError.new(topic[:rd_kafka_resp_err]) unless topic[:rd_kafka_resp_err].zero?
 
         partitions = Array.new(topic[:partition_count]) do |j|
           partition = PartitionMetadata.new(topic[:partitions_metadata] + (j * PartitionMetadata.size))
-          Rdkafka::RdkafkaError.new(partition[:rd_kafka_resp_err]) unless partition[:rd_kafka_resp_err].zero?
+          raise Rdkafka::RdkafkaError.new(partition[:rd_kafka_resp_err]) unless partition[:rd_kafka_resp_err].zero?
           partition.to_h
         end
         topic.to_h.merge!(partitions: partitions)

--- a/lib/rdkafka/producer.rb
+++ b/lib/rdkafka/producer.rb
@@ -52,6 +52,8 @@ module Rdkafka
     #
     # @param topic [String] The topic name.
     #
+    # @raise [RdkafkaError] When unable to retrieve the metadata
+    #
     # @return partition count [Integer,nil]
     #
     def partition_count(topic)


### PR DESCRIPTION
It seems rather unintentional to create an error just to throw it away.

Additionally, a point release would be much appreciated, since I ran into the incorrect error usage (https://github.com/appsignal/rdkafka-ruby/commit/16a4497f59f4d369ebfb4ad0784161400fd96424)