### PR TITLE
Allow passing in topic configuration on create_topic

### DIFF
--- a/lib/rdkafka/admin.rb
+++ b/lib/rdkafka/admin.rb
@@ -36,7 +36,7 @@ module Rdkafka
     # @raise [RdkafkaError] When the topic name is invalid or the topic already exists
     #
     # @return [CreateTopicHandle] Create topic handle that can be used to wait for the result of creating the topic
-    def create_topic(topic_name, partition_count, replication_factor)
+    def create_topic(topic_name, partition_count, replication_factor, topic_config={})
 
       # Create a rd_kafka_NewTopic_t representing the new topic
       error_buffer = FFI::MemoryPointer.from_string(" " * 256)
@@ -49,6 +49,16 @@ module Rdkafka
       )
       if new_topic_ptr.null?
         raise Rdkafka::Config::ConfigError.new(error_buffer.read_string)
+      end
+
+      unless topic_config.empty?
+        topic_config.each do |key, value|
+          Rdkafka::Bindings.rd_kafka_NewTopic_set_config(
+            new_topic_ptr,
+            key.to_s,
+            value.to_s
+          )
+        end
       end
 
       # Note that rd_kafka_CreateTopics can create more than one topic at a time

--- a/lib/rdkafka/admin.rb
+++ b/lib/rdkafka/admin.rb
@@ -52,7 +52,7 @@ module Rdkafka
         raise Rdkafka::Config::ConfigError.new(error_buffer.read_string)
       end
 
-      unless topic_config.empty?
+      unless topic_config.nil?
         topic_config.each do |key, value|
           Rdkafka::Bindings.rd_kafka_NewTopic_set_config(
             new_topic_ptr,

--- a/lib/rdkafka/admin.rb
+++ b/lib/rdkafka/admin.rb
@@ -34,6 +34,7 @@ module Rdkafka
     #
     # @raise [ConfigError] When the partition count or replication factor are out of valid range
     # @raise [RdkafkaError] When the topic name is invalid or the topic already exists
+    # @raise [RdkafkaError] When the topic configuration is invalid
     #
     # @return [CreateTopicHandle] Create topic handle that can be used to wait for the result of creating the topic
     def create_topic(topic_name, partition_count, replication_factor, topic_config={})

--- a/lib/rdkafka/bindings.rb
+++ b/lib/rdkafka/bindings.rb
@@ -252,6 +252,7 @@ module Rdkafka
 
     attach_function :rd_kafka_CreateTopics, [:pointer, :pointer, :size_t, :pointer, :pointer], :void
     attach_function :rd_kafka_NewTopic_new, [:pointer, :size_t, :size_t, :pointer, :size_t], :pointer
+    attach_function :rd_kafka_NewTopic_set_config, [:pointer, :string, :string], :int32
     attach_function :rd_kafka_NewTopic_destroy, [:pointer], :void
     attach_function :rd_kafka_event_CreateTopics_result, [:pointer], :pointer
     attach_function :rd_kafka_CreateTopics_result_topics, [:pointer, :pointer], :pointer


### PR DESCRIPTION
With the changes introduced in PR: https://github.com/appsignal/rdkafka-ruby/pull/123, our use case is to be able to specify the topic configuration for topics upon creation. This helps us automate this out when spinning up new environments, etc, so we don't have to go back afterwards to set such config options.

I would like to propose that we add this ability to the `create_topic` method as shown.

Please let me know if you have any questions / concerns / suggestions for me to change, thanks!