### PR TITLE
Add note about resource consumption

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,6 +72,10 @@ end
 delivery_handles.each(&:wait)
 ```
 
+Note that creating a producer consumes some resources that will not be
+released until it `#close` is explicitly called, so be sure to call 
+`Config#producer` only as necessary.
+
 ## Development
 
 A Docker Compose file is included to run Kafka and Zookeeper. To run


### PR DESCRIPTION
This bit me not too long ago, and I thought I'd try to make it a bit more visible. With what I think is a very-common configuration, every producer created spawns a new thread that is never released, so `Config.new(...).producer.produce(...)` is a bad thing to be doing.