### PR TITLE
Support Ruby 3.0

### DIFF
--- a/.semaphore/semaphore.yml
+++ b/.semaphore/semaphore.yml
@@ -13,7 +13,7 @@ blocks:
         - name: bundle exec rspec
           matrix:
             - env_var: RUBY_VERSION
-              values: [ "2.5.8", "2.6.6", "2.7.2", "jruby-9.2.13.0" ]
+              values: [ "2.5.8", "2.6.6", "2.7.2", "3.0.0-preview2", "jruby-9.2.13.0" ]
           commands:
             - sem-version ruby $RUBY_VERSION
             - checkout

--- a/ext/Rakefile
+++ b/ext/Rakefile
@@ -1,6 +1,7 @@
 require File.expand_path('../../lib/rdkafka/version', __FILE__)
 require "mini_portile2"
 require "fileutils"
+require "open-uri"
 
 task :default => :clean do
   # MiniPortile#download_file_http is a monkey patch that removes the download


### PR DESCRIPTION
While trying to install `rdkafka` with the latest Ruby 3.0 preview2 I get the following error:
```
$ docker run -it ruby:3.0.0-preview2 gem install rdkafka -v 0.8.1
Fetching rdkafka-0.8.1.gem
Fetching ffi-1.13.1.gem
Fetching mini_portile2-2.5.0.gem
Building native extensions. This could take a while...
Successfully installed ffi-1.13.1
Successfully installed mini_portile2-2.5.0
Building native extensions. This could take a while...
ERROR:  Error installing rdkafka:
	ERROR: Failed to build gem native extension.

    current directory: /usr/local/bundle/gems/rdkafka-0.8.1/ext
/usr/local/bin/ruby -I/usr/local/lib/ruby/3.0.0/rubygems -rrubygems /usr/local/lib/ruby/gems/3.0.0/gems/rake-13.0.1/exe/rake RUBYARCHDIR\=/usr/local/bundle/extensions/x86_64-linux/3.0.0/rdkafka-0.8.1 RUBYLIBDIR\=/usr/local/bundle/extensions/x86_64-linux/3.0.0/rdkafka-0.8.1
rake aborted!
NameError: uninitialized constant OpenURI::OpenSSL
/usr/local/bundle/gems/rdkafka-0.8.1/ext/Rakefile:14:in `block in download_file_http'
/usr/local/bundle/gems/mini_portile2-2.5.0/lib/mini_portile2/mini_portile.rb:543:in `with_tempfile'
/usr/local/bundle/gems/rdkafka-0.8.1/ext/Rakefile:12:in `download_file_http'
/usr/local/bundle/gems/mini_portile2-2.5.0/lib/mini_portile2/mini_portile.rb:440:in `download_file'
/usr/local/bundle/gems/mini_portile2-2.5.0/lib/mini_portile2/mini_portile.rb:54:in `block in download'
/usr/local/bundle/gems/mini_portile2-2.5.0/lib/mini_portile2/mini_portile.rb:53:in `each'
/usr/local/bundle/gems/mini_portile2-2.5.0/lib/mini_portile2/mini_portile.rb:53:in `download'
/usr/local/bundle/gems/mini_portile2-2.5.0/lib/mini_portile2/mini_portile.rb:150:in `cook'
/usr/local/bundle/gems/rdkafka-0.8.1/ext/Rakefile:37:in `block in <top (required)>'
Tasks: TOP => default
(See full trace by running task with --trace)

rake failed, exit code 1

Gem files will remain installed in /usr/local/bundle/gems/rdkafka-0.8.1 for inspection.
Results logged to /usr/local/bundle/extensions/x86_64-linux/3.0.0/rdkafka-0.8.1/gem_make.out
```

This happens because `OpenURI` was moved to a default gem in 3.0, and needs to be explicitly required now.

This PR requires `'open-uri'` before using `OpenURI`. This change still works with all supported versions of Ruby.