### PR TITLE
Allow any Callable Object for Callbacks

### DIFF
--- a/lib/rdkafka/config.rb
+++ b/lib/rdkafka/config.rb
@@ -33,11 +33,11 @@ module Rdkafka
     # You can configure if and how often this happens using `statistics.interval.ms`.
     # The callback is called with a hash that's documented here: https://github.com/edenhill/librdkafka/blob/master/STATISTICS.md
     #
-    # @param callback [Proc] The callback
+    # @param callback [Proc, #call] The callback
     #
     # @return [nil]
     def self.statistics_callback=(callback)
-      raise TypeError.new("Callback has to be a proc or lambda") unless callback.is_a? Proc
+      raise TypeError.new("Callback has to be callable") unless callback.respond_to?(:call)
       @@statistics_callback = callback
     end
 

--- a/lib/rdkafka/producer.rb
+++ b/lib/rdkafka/producer.rb
@@ -31,11 +31,11 @@ module Rdkafka
     # Set a callback that will be called every time a message is successfully produced.
     # The callback is called with a {DeliveryReport}
     #
-    # @param callback [Proc] The callback
+    # @param callback [Proc, #call] The callback
     #
     # @return [nil]
     def delivery_callback=(callback)
-      raise TypeError.new("Callback has to be a proc or lambda") unless callback.is_a? Proc
+      raise TypeError.new("Callback has to be callable") unless callback.respond_to?(:call)
       @delivery_callback = callback
     end
 

--- a/spec/rdkafka/config_spec.rb
+++ b/spec/rdkafka/config_spec.rb
@@ -21,16 +21,30 @@ describe Rdkafka::Config do
   end
 
   context "statistics callback" do
-    it "should set the callback" do
-      expect {
-        Rdkafka::Config.statistics_callback = lambda do |stats|
-          puts stats
-        end
-      }.not_to raise_error
-      expect(Rdkafka::Config.statistics_callback).to be_a Proc
+    context "with a proc/lambda" do
+      it "should set the callback" do
+        expect {
+          Rdkafka::Config.statistics_callback = lambda do |stats|
+            puts stats
+          end
+        }.not_to raise_error
+        expect(Rdkafka::Config.statistics_callback).to respond_to :call
+      end
     end
 
-    it "should not accept a callback that's not a proc" do
+    context "with a callable object" do
+      it "should set the callback" do
+        callback = Class.new do
+          def call(stats); end
+        end
+        expect {
+          Rdkafka::Config.statistics_callback = callback.new
+        }.not_to raise_error
+        expect(Rdkafka::Config.statistics_callback).to respond_to :call
+      end
+    end
+
+    it "should not accept a callback that's not callable" do
       expect {
         Rdkafka::Config.statistics_callback = 'a string'
       }.to raise_error(TypeError)

--- a/spec/rdkafka/producer_spec.rb
+++ b/spec/rdkafka/producer_spec.rb
@@ -21,38 +21,73 @@ describe Rdkafka::Producer do
       expect(producer.delivery_callback).to be_a Proc
     end
 
-    it "should not accept a callback that's not a proc" do
+    it "should not accept a callback that's not callable" do
       expect {
         producer.delivery_callback = 'a string'
       }.to raise_error(TypeError)
     end
 
-    it "should call the callback when a message is delivered" do
-      @callback_called = false
+    context "with a proc/lambda" do
+      it "should call the callback when a message is delivered" do
+        @callback_called = false
 
+        producer.delivery_callback = lambda do |report|
+          expect(report).not_to be_nil
+          expect(report.partition).to eq 1
+          expect(report.offset).to be >= 0
+          @callback_called = true
+        end
 
-      producer.delivery_callback = lambda do |report|
-        expect(report).not_to be_nil
-        expect(report.partition).to eq 1
-        expect(report.offset).to be >= 0
-        @callback_called = true
+        # Produce a message
+        handle = producer.produce(
+          topic:   "produce_test_topic",
+          payload: "payload",
+          key:     "key"
+        )
+
+        # Wait for it to be delivered
+        handle.wait(max_wait_timeout: 15)
+
+        # Join the producer thread.
+        producer.close
+
+        # Callback should have been called
+        expect(@callback_called).to be true
       end
+    end
 
-      # Produce a message
-      handle = producer.produce(
-        topic:   "produce_test_topic",
-        payload: "payload",
-        key:     "key"
-      )
+    context "with a callable object" do
+      it "should call the callback when a message is delivered" do
+        called_report = []
+        callback = Class.new do
+          def initialize(called_report)
+            @called_report = called_report
+          end
 
-      # Wait for it to be delivered
-      handle.wait(max_wait_timeout: 15)
+          def call(report)
+            @called_report << report
+          end
+        end
+        producer.delivery_callback = callback.new(called_report)
 
-      # Join the producer thread.
-      producer.close
+        # Produce a message
+        handle = producer.produce(
+          topic:   "produce_test_topic",
+          payload: "payload",
+          key:     "key"
+        )
 
-      # Callback should have been called
-      expect(@callback_called).to be true
+        # Wait for it to be delivered
+        handle.wait(max_wait_timeout: 15)
+
+        # Join the producer thread.
+        producer.close
+
+        # Callback should have been called
+        expect(called_report.first).not_to be_nil
+        expect(called_report.first.partition).to eq 1
+        expect(called_report.first.offset).to be >= 0
+      end
     end
   end
 

--- a/spec/rdkafka/producer_spec.rb
+++ b/spec/rdkafka/producer_spec.rb
@@ -21,27 +21,7 @@ describe Rdkafka::Producer do
         }.not_to raise_error
         expect(producer.delivery_callback).to respond_to :call
       end
-    end
 
-    context "with a callable object" do
-      it "should set the callback" do
-        callback = Class.new do
-          def call(stats); end
-        end
-        expect {
-          producer.delivery_callback = callback.new
-        }.not_to raise_error
-        expect(producer.delivery_callback).to respond_to :call
-      end
-    end
-
-    it "should not accept a callback that's not callable" do
-      expect {
-        producer.delivery_callback = 'a string'
-      }.to raise_error(TypeError)
-    end
-
-    context "with a proc/lambda" do
       it "should call the callback when a message is delivered" do
         @callback_called = false
 
@@ -71,6 +51,16 @@ describe Rdkafka::Producer do
     end
 
     context "with a callable object" do
+      it "should set the callback" do
+        callback = Class.new do
+          def call(stats); end
+        end
+        expect {
+          producer.delivery_callback = callback.new
+        }.not_to raise_error
+        expect(producer.delivery_callback).to respond_to :call
+      end
+
       it "should call the callback when a message is delivered" do
         called_report = []
         callback = Class.new do
@@ -102,6 +92,12 @@ describe Rdkafka::Producer do
         expect(called_report.first.partition).to eq 1
         expect(called_report.first.offset).to be >= 0
       end
+    end
+
+    it "should not accept a callback that's not callable" do
+      expect {
+        producer.delivery_callback = 'a string'
+      }.to raise_error(TypeError)
     end
   end
 

--- a/spec/rdkafka/producer_spec.rb
+++ b/spec/rdkafka/producer_spec.rb
@@ -12,13 +12,27 @@ describe Rdkafka::Producer do
   end
 
   context "delivery callback" do
-    it "should set the callback" do
-      expect {
-        producer.delivery_callback = lambda do |delivery_handle|
-          puts stats
+    context "with a proc/lambda" do
+      it "should set the callback" do
+        expect {
+          producer.delivery_callback = lambda do |delivery_handle|
+            puts delivery_handle
+          end
+        }.not_to raise_error
+        expect(producer.delivery_callback).to respond_to :call
+      end
+    end
+
+    context "with a callable object" do
+      it "should set the callback" do
+        callback = Class.new do
+          def call(stats); end
         end
-      }.not_to raise_error
-      expect(producer.delivery_callback).to be_a Proc
+        expect {
+          producer.delivery_callback = callback.new
+        }.not_to raise_error
+        expect(producer.delivery_callback).to respond_to :call
+      end
     end
 
     it "should not accept a callback that's not callable" do
@@ -27,67 +41,31 @@ describe Rdkafka::Producer do
       }.to raise_error(TypeError)
     end
 
-    context "with a proc/lambda" do
-      it "should call the callback when a message is delivered" do
-        @callback_called = false
+    it "should call the callback when a message is delivered" do
+      @callback_called = false
 
-        producer.delivery_callback = lambda do |report|
-          expect(report).not_to be_nil
-          expect(report.partition).to eq 1
-          expect(report.offset).to be >= 0
-          @callback_called = true
-        end
-
-        # Produce a message
-        handle = producer.produce(
-          topic:   "produce_test_topic",
-          payload: "payload",
-          key:     "key"
-        )
-
-        # Wait for it to be delivered
-        handle.wait(max_wait_timeout: 15)
-
-        # Join the producer thread.
-        producer.close
-
-        # Callback should have been called
-        expect(@callback_called).to be true
+      producer.delivery_callback = lambda do |report|
+        expect(report).not_to be_nil
+        expect(report.partition).to eq 1
+        expect(report.offset).to be >= 0
+        @callback_called = true
       end
-    end
 
-    context "with a callable object" do
-      it "should call the callback when a message is delivered" do
-        called_report = []
-        callback = Class.new do
-          def initialize(called_report)
-            @called_report = called_report
-          end
+      # Produce a message
+      handle = producer.produce(
+        topic:   "produce_test_topic",
+        payload: "payload",
+        key:     "key"
+      )
 
-          def call(report)
-            @called_report << report
-          end
-        end
-        producer.delivery_callback = callback.new(called_report)
+      # Wait for it to be delivered
+      handle.wait(max_wait_timeout: 15)
 
-        # Produce a message
-        handle = producer.produce(
-          topic:   "produce_test_topic",
-          payload: "payload",
-          key:     "key"
-        )
+      # Join the producer thread.
+      producer.close
 
-        # Wait for it to be delivered
-        handle.wait(max_wait_timeout: 15)
-
-        # Join the producer thread.
-        producer.close
-
-        # Callback should have been called
-        expect(called_report.first).not_to be_nil
-        expect(called_report.first.partition).to eq 1
-        expect(called_report.first.offset).to be >= 0
-      end
+      # Callback should have been called
+      expect(@callback_called).to be true
     end
   end
 


### PR DESCRIPTION
When using callbacks (either for statistics or for producer delivery) it would be nice to be able to use something other than a Proc. For example, when handling statistics it may helpful to encapsulate handling logic into its own class.

This updates the type checking such that any object responding to `#call` can be used as a callback.