### PR TITLE
GSSAPI Support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,7 @@ ext/librdkafka.*
 .yardoc
 doc
 coverage
+scripts/secrets/*
+!scripts/secrets/krb5.conf
+!scripts/secrets/zookeeper-jaas.conf
+!scripts/secrets/kafka-jaas.conf

--- a/ext/Rakefile
+++ b/ext/Rakefile
@@ -66,7 +66,8 @@ namespace :build do
 
     recipe = MiniPortile.new("librdkafka", version)
     recipe.files << "https://github.com/edenhill/librdkafka/archive/#{ref}.tar.gz"
-    recipe.configure_options = ["--host=#{recipe.host}","--enable-static", "--enable-zstd"]
+    recipe.configure_options = ["--host=#{recipe.host}","--enable-static", "--enable-zstd", "--enable-ssl"]
+    #recipe.configure_options = ["--host=#{recipe.host}","--enable-static", "--enable-zstd"]
     recipe.cook
 
     ext = recipe.host.include?("darwin") ? "dylib" : "so"

--- a/scripts/create-certs.sh
+++ b/scripts/create-certs.sh
@@ -1,0 +1,56 @@
+#!/bin/bash
+
+set -o nounset \
+    -o errexit \
+
+# Clean up old certs from secrets directory only
+DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )/secrets" >/dev/null && pwd )"
+cd "${DIR}" && rm -f *.crt *.csr *_creds *.jks *.srl *.key *.pem *.der *.p12
+
+cd "${DIR}"
+# Generate CA Key and cert
+openssl req -new -x509 -keyout ca.key -out ca.crt -days 365 \
+    -subj '/CN=ca/OU=TEST/O=TEST/L=Toronto/S=ON/C=CA' \
+    -passin pass:changeme -passout pass:changeme
+
+for i in kafka.confluent.io
+do
+	echo $i
+	# Create keystores
+	keytool -genkey -noprompt \
+				 -alias $i \
+				 -dname "CN=$i, OU=TEST, O=TEST, L=Toronto, S=ON, C=CA" \
+				 -keystore $i.keystore.jks \
+                 -storetype PKCS12 \
+				 -keyalg RSA \
+				 -storepass changeme \
+				 -keypass changeme 
+
+	# Create CSR, sign the key and import back into keystore
+	keytool -keystore $i.keystore.jks -alias $i -certreq -file $i.csr -storepass changeme -keypass changeme
+
+	openssl x509 -req -CA ca.crt -CAkey ca.key -in $i.csr -out $i-ca-signed.crt -days 9999 -CAcreateserial -passin pass:changeme
+
+	keytool -noprompt -keystore $i.keystore.jks -alias CARoot -import -file ca.crt -storepass changeme -keypass changeme
+
+	keytool -noprompt -keystore $i.keystore.jks -alias $i -import -file $i-ca-signed.crt -storepass changeme -keypass changeme 
+
+	# Create truststore and import the CA cert.
+	keytool -noprompt -keystore $i.truststore.jks -alias CARoot -import -file ca.crt -storepass changeme -keypass changeme
+
+  # Write jks creds to files needed by kafka-images/.../docker/configure
+  echo "changeme" > ${i}_sslkey_creds
+  echo "changeme" > ${i}_keystore_creds
+  echo "changeme" > ${i}_truststore_creds
+done
+
+# Generating public and private keys for token signing
+  echo "Generating public and private keys for token signing"
+  mkdir -p keypair
+  openssl genrsa -out keypair/keypair.pem 2048
+  openssl rsa -in keypair/keypair.pem -outform PEM -pubout -out keypair/public.pem
+
+  # Enable Docker appuser to read files when created by a different UID
+  echo -e "Setting insecure permissions on some files in ${DIR}...\n"
+  chmod 644 keypair/keypair.pem
+  chmod 644 *.key

--- a/scripts/docker-compose-sasl.yml
+++ b/scripts/docker-compose-sasl.yml
@@ -1,0 +1,83 @@
+---
+version: '2'
+
+services:
+  kerberos:
+    image: confluentinc/cp-kerberos:latest
+    container_name: kerberos
+    hostname: 'kerberos.confluent.io'
+    networks:
+      - confluent.io
+    ports:
+      - "88:88/udp"
+    environment:
+      BOOTSTRAP: 0
+    volumes:
+      - ./secrets:/tmp/keytab
+      - /dev/urandom:/dev/random
+
+  zookeeper:
+    image: confluentinc/cp-zookeeper:latest
+    container_name: zookeeper
+    hostname: 'zookeeper.confluent.io'
+    networks:
+      - confluent.io
+    restart: always
+    depends_on:
+      - kerberos
+    environment:
+      ZOOKEEPER_SERVER_ID: 1
+      ZOOKEEPER_CLIENT_PORT: 2181
+      ZOOKEEPER_TICK_TIME: 2000
+      ZOOKEEPER_INIT_LIMIT: 5
+      ZOOKEEPER_SYNC_LIMIT: 2
+      ZOOKEEPER_AUTH_PROVIDER_SASL: org.apache.zookeeper.server.auth.SASLAuthenticationProvider
+      KAFKA_OPTS: -Djava.security.auth.login.config=/etc/kafka/secrets/zookeeper-jaas.conf
+        -Dsun.security.krb5.debug=true
+    volumes:
+      - ./secrets:/etc/kafka/secrets:rw
+      - ./secrets/krb5.conf:/etc/krb5.conf
+
+  kafka:
+    image: confluentinc/cp-kafka:latest
+    hostname: 'kafka.confluent.io'
+    container_name: kafka
+    networks:
+      - confluent.io
+    ports:
+      - "9094:9094"
+      - "9092:9092"
+    depends_on:
+      - zookeeper
+      - kerberos
+    environment:
+      KAFKA_BROKER_ID: 1
+      KAFKA_ZOOKEEPER_CONNECT: zookeeper.confluent.io:2181
+      KAFKA_ADVERTISED_LISTENERS: SASL_SSL://kafka.confluent.io:9094,PLAINTEXT://kafka.confluent.io:9092
+      KAFKA_LISTENER_SECURITY_PROTOCOL_MAP: SASL_SSL:SASL_SSL,PLAINTEXT:PLAINTEXT
+      KAFKA_SSL_KEYSTORE_FILENAME: kafka.confluent.io.keystore.jks
+      KAFKA_SSL_KEYSTORE_CREDENTIALS: kafka.confluent.io_keystore_creds
+      KAFKA_SSL_KEY_CREDENTIALS: kafka.confluent.io_sslkey_creds
+      KAFKA_SSL_TRUSTSTORE_FILENAME: kafka.confluent.io.truststore.jks
+      KAFKA_SSL_TRUSTSTORE_CREDENTIALS: kafka.confluent.io_truststore_creds
+      KAFKA_INTER_BROKER_LISTENER_NAME: SASL_PLAINTEXT
+      KAFKA_SASL_MECHANISM_INTER_BROKER_PROTOCOL: GSSAPI
+      KAFKA_SASL_ENABLED_MECHANISMS: GSSAPI
+      KAFKA_SASL_KERBEROS_SERVICE_NAME: kafka
+      KAFKA_LOG4J_ROOT_LOGLEVEL: DEBUG
+      KAFKA_OFFSETS_TOPIC_REPLICATION_FACTOR: 1
+      KAFKA_OPTS: -Djava.security.auth.login.config=/etc/kafka/secrets/kafka-jaas.conf
+        -Dsun.security.krb5.debug=true
+    volumes:
+      - ./secrets:/etc/kafka/secrets:rw
+      - ./secrets/krb5.conf:/etc/krb5.conf
+
+networks:
+  confluent.io:
+    name: confluent.io
+
+
+# References
+# Confluent Kafka Docker compose: https://github.com/confluentinc/kafka-images/blob/master/examples/kafka-cluster-sasl/docker-compose.yml
+# References for all supported env vars by these docker images(zookeeper): https://github.com/confluentinc/kafka-images/blob/master/zookeeper/include/etc/confluent/docker/zookeeper.properties.template
+# Troubleshooting client -> kafka communication issues: https://www.confluent.io/blog/kafka-client-cannot-connect-to-broker-on-aws-on-docker-etc/

--- a/scripts/kdc-admin/CentOS-Base.repo
+++ b/scripts/kdc-admin/CentOS-Base.repo
@@ -1,0 +1,25 @@
+[base]
+name=CentOS-$releasever - Base
+# mirrorlist=http://mirrorlist.centos.org/?release=$releasever&arch=$basearch&repo=os&infra=$infra
+# baseurl=http://mirror.centos.org/centos/$releasever/os/$basearch/
+baseurl=https://vault.centos.org/6.10/os/$basearch/
+gpgcheck=1
+gpgkey=file:///etc/pki/rpm-gpg/RPM-GPG-KEY-CentOS-6
+
+# released updates
+[updates]
+name=CentOS-$releasever - Updates
+# mirrorlist=http://mirrorlist.centos.org/?release=$releasever&arch=$basearch&repo=updates&infra=$infra
+# baseurl=http://mirror.centos.org/centos/$releasever/updates/$basearch/
+baseurl=https://vault.centos.org/6.10/updates/$basearch/
+gpgcheck=1
+gpgkey=file:///etc/pki/rpm-gpg/RPM-GPG-KEY-CentOS-6
+
+# additional packages that may be useful
+[extras]
+name=CentOS-$releasever - Extras
+# mirrorlist=http://mirrorlist.centos.org/?release=$releasever&arch=$basearch&repo=extras&infra=$infra
+# baseurl=http://mirror.centos.org/centos/$releasever/extras/$basearch/
+baseurl=https://vault.centos.org/6.10/extras/$basearch/
+gpgcheck=1
+gpgkey=file:///etc/pki/rpm-gpg/RPM-GPG-KEY-CentOS-6

--- a/scripts/kdc-admin/Dockerfile
+++ b/scripts/kdc-admin/Dockerfile
@@ -1,0 +1,25 @@
+FROM centos:6
+
+ARG COMMIT_ID=unknown
+LABEL io.confluent.docker.git.id=$COMMIT_ID
+ARG BUILD_NUMBER=-1
+LABEL io.confluent.docker.build.number=$BUILD_NUMBER
+LABEL io.confluent.docker=true
+
+# EPEL
+#RUN yum install -y epel-release
+
+COPY CentOS-Base.repo /etc/yum.repos.d/
+
+# kerberos
+RUN yum clean all -y \
+    && yum update -y \
+    && yum install -y krb5-server krb5-libs krb5-auth-dialog krb5-workstation
+
+EXPOSE 88 749
+
+ADD ./config.sh /config.sh
+
+RUN mkdir /etc/krb5kdc
+
+ENTRYPOINT ["/config.sh"]

--- a/scripts/kdc-admin/config.sh
+++ b/scripts/kdc-admin/config.sh
@@ -1,0 +1,112 @@
+#!/bin/bash
+
+[[ "TRACE" ]] && set -x
+
+: ${REALM:=TEST.CONFLUENT.IO}
+: ${DOMAIN_REALM:=test.confluent.io}
+: ${KERB_MASTER_KEY:=masterkey}
+: ${KERB_ADMIN_USER:=admin}
+: ${KERB_ADMIN_PASS:=admin}
+
+
+
+create_config() {
+  : ${KDC_ADDRESS:=kerberos.confluent.io}
+
+  cat>/etc/krb5.conf<<EOF
+[logging]
+ default = FILE:/var/log/kerberos/krb5libs.log
+ kdc = FILE:/var/log/kerberos/krb5kdc.log
+ admin_server = FILE:/var/log/kerberos/kadmind.log
+
+[libdefaults]
+ default_realm = $REALM
+ dns_lookup_realm = false
+ dns_lookup_kdc = false
+ ticket_lifetime = 24h
+ renew_lifetime = 7d
+ forwardable = true
+ # WARNING: We use weaker key types to simplify testing as stronger key types
+ # require the enhanced security JCE policy file to be installed. You should
+ # NOT run with this configuration in production or any real environment. You
+ # have been warned.
+ default_tkt_enctypes = des-cbc-md5 des-cbc-crc des3-cbc-sha1
+ default_tgs_enctypes = des-cbc-md5 des-cbc-crc des3-cbc-sha1
+ permitted_enctypes = des-cbc-md5 des-cbc-crc des3-cbc-sha1
+
+[realms]
+ $REALM = {
+  kdc = $KDC_ADDRESS
+  admin_server = $KDC_ADDRESS
+ }
+
+[domain_realm]
+ .$DOMAIN_REALM = $REALM
+ $DOMAIN_REALM = $REALM
+EOF
+
+cat>/etc/krb5kdc/kdc.conf<<EOF
+[kdcdefaults]
+ kdc_ports = 8888
+ kdc_tcp_ports = 8888
+
+[realms]
+ $REALM = {
+  acl_file = /etc/krb5kdc/kadm5.acl
+  dict_file = /usr/share/dict/words
+  admin_keytab = /etc/krb5kdc/kadm5.keytab
+  # WARNING: We use weaker key types to simplify testing as stronger key types
+  # require the enhanced security JCE policy file to be installed. You should
+  # NOT run with this configuration in production or any real environment. You
+  # have been warned.
+  master_key_type = des3-hmac-sha1
+  supported_enctypes = arcfour-hmac:normal des3-hmac-sha1:normal des-cbc-crc:normal des:normal des:v4 des:norealm des:onlyrealm des:afs3
+  default_principal_flags = +preauth
+ }
+EOF
+}
+
+create_db() {
+  /usr/sbin/kdb5_util -P $KERB_MASTER_KEY -r $REALM create -s
+}
+
+start_kdc() {
+  mkdir -p /var/log/kerberos
+
+  /etc/rc.d/init.d/krb5kdc start
+  /etc/rc.d/init.d/kadmin start
+
+  chkconfig krb5kdc on
+  chkconfig kadmin on
+}
+
+restart_kdc() {
+  /etc/rc.d/init.d/krb5kdc restart
+  /etc/rc.d/init.d/kadmin restart
+}
+
+create_admin_user() {
+  kadmin.local -q "addprinc -pw $KERB_ADMIN_PASS $KERB_ADMIN_USER/admin"
+  echo "*/admin@$REALM *" > /etc/krb5kdc/kadm5.acl
+}
+
+main() {
+
+  if [ ! -f /kerberos_initialized ]; then
+    create_config
+    create_db
+    create_admin_user
+    start_kdc
+
+    touch /kerberos_initialized
+  fi
+
+  if [ ! -f /etc/krb5kdc/principal ]; then
+    while true; do sleep 1000; done
+  else
+    start_kdc
+    tail -F /var/log/kerberos/krb5kdc.log
+  fi
+}
+
+[[ "$0" == "$BASH_SOURCE" ]] && main "$@"

--- a/scripts/secrets/kafka-jaas.conf
+++ b/scripts/secrets/kafka-jaas.conf
@@ -1,0 +1,28 @@
+KafkaServer {
+    com.sun.security.auth.module.Krb5LoginModule required
+    useKeyTab=true
+    storeKey=true
+    keyTab="/etc/kafka/secrets/kafka.keytab"
+    principal="kafka/kafka.confluent.io@TEST.CONFLUENT.IO";
+};
+
+
+KafkaClient {
+    com.sun.security.auth.module.Krb5LoginModule required
+    useKeyTab=true
+    storeKey=true
+    keyTab="/etc/kafka/secrets/kafka.keytab"
+    principal="kafka/kafka.confluent.io@TEST.CONFLUENT.IO";
+};
+
+/*
+* Zookeeper client
+*/
+Client {
+    com.sun.security.auth.module.Krb5LoginModule required
+    useKeyTab=true
+    storeKey=true
+    useTicketCache=false
+    keyTab="/etc/kafka/secrets/kafka.keytab"
+    principal="kafka/kafka.confluent.io@TEST.CONFLUENT.IO";
+};

--- a/scripts/secrets/krb5.conf
+++ b/scripts/secrets/krb5.conf
@@ -1,0 +1,22 @@
+[logging]
+ default = FILE:/var/log/kerberos/krb5libs.log
+ kdc = FILE:/var/log/kerberos/krb5kdc.log
+ admin_server = FILE:/var/log/kerberos/kadmind.log
+
+[libdefaults]
+ default_realm = TEST.CONFLUENT.IO
+ dns_lookup_realm = false
+ dns_lookup_kdc = true
+ ticket_lifetime = 24h
+ renew_lifetime = 7d
+ forwardable = true
+
+[realms]
+ TEST.CONFLUENT.IO = {
+  kdc = kerberos.confluent.io
+  admin_server = kerberos.confluent.io
+ }
+
+[domain_realm]
+ .test.confluent.io = TEST.CONFLUENT.IO
+ test.confluent.io = TEST.CONFLUENT.IO

--- a/scripts/secrets/zookeeper-jaas.conf
+++ b/scripts/secrets/zookeeper-jaas.conf
@@ -1,0 +1,8 @@
+Server {
+    com.sun.security.auth.module.Krb5LoginModule required
+    useKeyTab=true
+    storeKey=true
+    useTicketCache=true
+    keyTab="/etc/kafka/secrets/zookeeper.keytab"
+    principal="zookeeper/zookeeper.confluent.io@TEST.CONFLUENT.IO";
+};

--- a/scripts/start.sh
+++ b/scripts/start.sh
@@ -1,0 +1,30 @@
+#!/bin/bash
+DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null && pwd )"
+
+# stop running docker-compose containers
+docker-compose down --volumes --remove-orphans
+
+# Create SSL Certificates and Java keystores
+${DIR}/create-certs.sh
+
+cd ${DIR}
+echo "Starting kerberos container..."
+docker-compose -f docker-compose-sasl.yml up --build -d kerberos
+
+## Step-1
+echo "Creating Service Principals..."
+principals=(zookeeper kafka producer consumer)
+
+for principal in ${principals[@]}; do
+    # Delete existing keytabs before creating new ones
+    docker exec -i kerberos rm -f /tmp/keytab/${principal}.keytab 2>&1 > /dev/null
+    docker exec -i kerberos kadmin.local -w password -q "addprinc -randkey ${principal}/${principal}.confluent.io@TEST.CONFLUENT.IO"
+    docker exec -i kerberos kadmin.local -w password -q "ktadd -norandkey -k /tmp/keytab/${principal}.keytab ${principal}/${principal}.confluent.io@TEST.CONFLUENT.IO"
+    # keytabs are created on kerberos container with root user
+    # ubi8 confluent images starting from version 6.x use 'appuser' user
+    # adjusting keytab permissions
+    docker exec -i kerberos chmod a+r /tmp/keytab/${principal}.keytab
+done
+
+# start zookeeper and kafka in background
+docker-compose -f ${DIR}/docker-compose-sasl.yml up -d


### PR DESCRIPTION
- Adding docker-compose-sasl.yml to support testing of SASL_SSL authentication. 
- Added --enable-ssl option for librdkafka installation.


Note:
- The docker-compose includes hostnames like kafka.confluent.io etc, please modify your /etc/hosts file to support these names. My /etc/hosts file:
- `127.0.0.1       localhost zookeeper.confluent.io kerberos.confluent.io consumer.confluent.io
    <my-ip> kafka.confluent.io`

- Use krb5.conf from scripts/secrets/krb5.conf to be able to test producer and consumer clients.