### PR TITLE
Add configuration for error callbacks

### DIFF
--- a/lib/rdkafka/config.rb
+++ b/lib/rdkafka/config.rb
@@ -10,6 +10,8 @@ module Rdkafka
     # @private
     @@statistics_callback = nil
     # @private
+    @@error_callback = nil
+    # @private
     @@opaques = {}
     # @private
     @@log_queue = Queue.new
@@ -27,6 +29,7 @@ module Rdkafka
     def self.logger
       @@logger
     end
+
 
     # Returns a queue whose contents will be passed to the configured logger. Each entry
     # should follow the format [Logger::Severity, String]. The benefit over calling the
@@ -64,6 +67,25 @@ module Rdkafka
     # @return [Proc, nil]
     def self.statistics_callback
       @@statistics_callback
+    end
+
+    # Set a callback that will be called every time the underlying client emits an error.
+    # If this callback is not set, global errors such as brokers becoming unavailable will only be sent to the logger, as defined by librdkafka.
+    # The callback is called with an instance of RdKafka::Error.
+    #
+    # @param callback [Proc, #call] The callback
+    #
+    # @return [nil]
+    def self.error_callback=(callback)
+      raise TypeError.new("Callback has to be callable") unless callback.respond_to?(:call)
+      @@error_callback = callback
+    end
+
+    # Returns the current error callback, by default this is nil.
+    #
+    # @return [Proc, nil]
+    def self.error_callback
+      @@error_callback
     end
 
     # @private
@@ -221,6 +243,9 @@ module Rdkafka
 
         # Set stats callback
         Rdkafka::Bindings.rd_kafka_conf_set_stats_cb(config, Rdkafka::Bindings::StatsCallback)
+
+        # Set error callback
+        Rdkafka::Bindings.rd_kafka_conf_set_error_cb(config, Rdkafka::Bindings::ErrorCallback)
       end
     end
 

--- a/spec/rdkafka/bindings_spec.rb
+++ b/spec/rdkafka/bindings_spec.rb
@@ -100,4 +100,28 @@ describe Rdkafka::Bindings do
       end
     end
   end
+
+  describe "error callback" do
+    context "without an error callback" do
+      it "should do nothing" do
+        expect {
+          Rdkafka::Bindings::ErrorCallback.call(nil, 1, "error", nil)
+        }.not_to raise_error
+      end
+    end
+
+    context "with an error callback" do
+      before do
+        Rdkafka::Config.error_callback = lambda do |error|
+          $received_error = error
+        end
+      end
+
+      it "should call the error callback with an Rdkafka::Error" do
+        Rdkafka::Bindings::ErrorCallback.call(nil, 8, "Broker not available", nil)
+        expect($received_error.code).to eq(:broker_not_available)
+        expect($received_error.broker_message).to eq("Broker not available")
+      end
+    end
+  end
 end

--- a/spec/rdkafka/config_spec.rb
+++ b/spec/rdkafka/config_spec.rb
@@ -64,6 +64,37 @@ describe Rdkafka::Config do
     end
   end
 
+  context "error callback" do
+    context "with a proc/lambda" do
+      it "should set the callback" do
+        expect {
+          Rdkafka::Config.error_callback = lambda do |error|
+            puts error
+          end
+        }.not_to raise_error
+        expect(Rdkafka::Config.error_callback).to respond_to :call
+      end
+    end
+
+    context "with a callable object" do
+      it "should set the callback" do
+        callback = Class.new do
+          def call(stats); end
+        end
+        expect {
+          Rdkafka::Config.error_callback = callback.new
+        }.not_to raise_error
+        expect(Rdkafka::Config.error_callback).to respond_to :call
+      end
+    end
+
+    it "should not accept a callback that's not callable" do
+      expect {
+        Rdkafka::Config.error_callback = 'a string'
+      }.to raise_error(TypeError)
+    end
+  end
+
   context "configuration" do
     it "should store configuration" do
       config = Rdkafka::Config.new


### PR DESCRIPTION
Adds configuration to use a global error callback as described in the C API here: https://docs.confluent.io/2.0.0/clients/librdkafka/rdkafka_8h.html#ace721ef3b7c22d0c111ec747ef039a90

The reason for this is that many errors are not surfaced in the consumer and are instead directed to the logger. Setting an error callback allows the consumer to react to these errors without inspecting the statistics payload.