### PR TITLE
small styling remarks, additional docs and typos fixes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -41,7 +41,7 @@
 * Use default Homebrew openssl location if present
 * Consumer lag handles empty topics
 * End iteration in consumer when it is closed
-* Add suport for storing message offsets
+* Add support for storing message offsets
 * Add missing runtime dependency to rake
 
 # 0.4.1

--- a/ext/README.md
+++ b/ext/README.md
@@ -1,6 +1,6 @@
 # Ext
 
-This gem dependes on the `librdkafka` C library. It is downloaded when
+This gem depends on the `librdkafka` C library. It is downloaded when
 this gem is installed.
 
 To update the `librdkafka` version follow the following steps:

--- a/lib/rdkafka/consumer.rb
+++ b/lib/rdkafka/consumer.rb
@@ -498,11 +498,11 @@ module Rdkafka
     # Exception behavior is more complicated than with `each`, in that if
     # :yield_on_error is true, and an exception is raised during the
     # poll, and messages have already been received, they will be yielded to
-    # the caller before the exception is allowed to propogate.
+    # the caller before the exception is allowed to propagate.
     #
     # If you are setting either auto.commit or auto.offset.store to false in
     # the consumer configuration, then you should let yield_on_error keep its
-    # default value of false because you are gauranteed to see these messages
+    # default value of false because you are guaranteed to see these messages
     # again. However, if both auto.commit and auto.offset.store are set to
     # true, you should set yield_on_error to true so you can process messages
     # that you may or may not see again.
@@ -518,7 +518,7 @@ module Rdkafka
     # @yield [messages, pending_exception]
     # @yieldparam messages [Array] An array of received Message
     # @yieldparam pending_exception [Exception] normally nil, or an exception
-    # which will be propogated after processing of the partial batch is complete.
+    # which will be propagated after processing of the partial batch is complete.
     #
     # @return [nil]
     def each_batch(max_items: 100, bytes_threshold: Float::INFINITY, timeout_ms: 250, yield_on_error: false, &block)

--- a/lib/rdkafka/producer.rb
+++ b/lib/rdkafka/producer.rb
@@ -75,8 +75,9 @@ module Rdkafka
     #
     # @param topic [String] The topic to produce to
     # @param payload [String,nil] The message's payload
-    # @param key [String] The message's key
+    # @param key [String, nil] The message's key
     # @param partition [Integer,nil] Optional partition to produce to
+    # @param partition_key [String, nil] Optional partition key based on which partition assignment can happen
     # @param timestamp [Time,Integer,nil] Optional timestamp of this message. Integer timestamp is in milliseconds since Jan 1 1970.
     # @param headers [Hash<String,String>] Optional message headers
     #

--- a/lib/rdkafka/producer/delivery_report.rb
+++ b/lib/rdkafka/producer/delivery_report.rb
@@ -11,7 +11,7 @@ module Rdkafka
       attr_reader :offset
 
       # Error in case happen during produce.
-      # @return [string]
+      # @return [String]
       attr_reader :error
 
       private

--- a/spec/rdkafka/abstract_handle_spec.rb
+++ b/spec/rdkafka/abstract_handle_spec.rb
@@ -111,4 +111,3 @@ describe Rdkafka::AbstractHandle do
     end
   end
 end
-


### PR DESCRIPTION
This PR fixes some things that were irritating me ;)

If:
- fixes multiple empty lines at the end of files (actually 1 file)
- fixes typos in the code docs
- adds additional doc for producer production method to cover all the args

based on report from https://app.coditsu.io/mensfeld/repositories/rdkafka/builds/commit_builds