### PR TITLE
Use Homebrew prefix when setting OpenSSL compile flags

### DIFF
--- a/ext/Rakefile
+++ b/ext/Rakefile
@@ -25,9 +25,9 @@ task :default => :clean do
 
   # Use default homebrew openssl if we're on mac and the directory exists
   # and each of flags is not empty
-  if recipe.host&.include?("darwin") && Dir.exist?("/usr/local/opt/openssl")
-    ENV["CPPFLAGS"] = "-I/usr/local/opt/openssl/include" unless ENV["CPPFLAGS"]
-    ENV["LDFLAGS"] = "-L/usr/local/opt/openssl/lib" unless ENV["LDFLAGS"]
+  if recipe.host&.include?("darwin") && system("which brew &> /dev/null") && Dir.exist?("#{homebrew_prefix = %x(brew --prefix).strip}/opt/openssl")
+    ENV["CPPFLAGS"] = "-I#{homebrew_prefix}/opt/openssl/include" unless ENV["CPPFLAGS"]
+    ENV["LDFLAGS"] = "-L#{homebrew_prefix}/opt/openssl/lib" unless ENV["LDFLAGS"]
   end
 
   recipe.files << {


### PR DESCRIPTION
Homebrew on Apple Silicon/ARM uses `/opt/homebrew` [path prefix ](https://docs.brew.sh/FAQ#why-should-i-install-homebrew-in-the-default-location)instead of `/usr/local` (used by Intel Macs).

The [issue has been identified in the `zendesk/racecar` repo](https://github.com/zendesk/racecar/issues/255) but I believe this commit should fix the problem.

[1]: https://docs.brew.sh/FAQ#why-should-i-install-homebrew-in-the-default-location
[2]: https://github.com/zendesk/racecar/issues/255