### PR TITLE
Use brew --prefix [formula] to find openssl on a mac

### DIFF
--- a/ext/Rakefile
+++ b/ext/Rakefile
@@ -9,9 +9,9 @@ task :default => :clean do
 
   # Use default homebrew openssl if we're on mac and the directory exists
   # and each of flags is not empty
-  if recipe.host&.include?("darwin") && system("which brew &> /dev/null") && Dir.exist?("#{homebrew_prefix = %x(brew --prefix).strip}/opt/openssl")
-    ENV["CPPFLAGS"] = "-I#{homebrew_prefix}/opt/openssl/include" unless ENV["CPPFLAGS"]
-    ENV["LDFLAGS"] = "-L#{homebrew_prefix}/opt/openssl/lib" unless ENV["LDFLAGS"]
+  if recipe.host&.include?("darwin") && system("which brew &> /dev/null") && Dir.exist?("#{homebrew_prefix = %x(brew --prefix openssl).strip}")
+    ENV["CPPFLAGS"] = "-I#{homebrew_prefix}/include" unless ENV["CPPFLAGS"]
+    ENV["LDFLAGS"] = "-L#{homebrew_prefix}/lib" unless ENV["LDFLAGS"]
   end
 
   recipe.files << {


### PR DESCRIPTION
This is a follow-up to #167 that addressed changes to openssl in Homebrew.

brew --prefix has a form that returns a path to a specific formula instead of the general brew installation path.

This method of resolving paths is preferred because homebrew started to add suffixes to openssl installation to distinguish 1.1 vs 3.0, so openssl started to be installed into `/opt/homebrew/opt/openssl@3` and `/opt/homebrew/opt/openssl@1.1` instead of the expected `/ops/homebrew/opt/openssl`.

[Here is the homebrew change](https://github.com/Homebrew/homebrew-core/pull/85730) which added openssl@3 and made it a default installation path.