### PR TITLE
Add guard and focus

### DIFF
--- a/Guardfile
+++ b/Guardfile
@@ -1,0 +1,19 @@
+# frozen_string_literal: true
+
+logger level: :error
+
+guard :rspec, cmd: "bundle exec rspec --format #{ENV.fetch("FORMAT", "documentation")}" do
+  require "guard/rspec/dsl"
+  dsl = Guard::RSpec::Dsl.new(self)
+
+  # Ruby files
+  ruby = dsl.ruby
+  dsl.watch_spec_files_for(ruby.lib_files)
+  watch(%r{^lib/(.+)\.rb}) { |m| "spec/#{m[1]}_spec.rb" }
+
+  # RSpec files
+  rspec = dsl.rspec
+  watch(rspec.spec_helper) { rspec.spec_dir }
+  watch(rspec.spec_support) { rspec.spec_dir }
+  watch(rspec.spec_files)
+end

--- a/rdkafka.gemspec
+++ b/rdkafka.gemspec
@@ -25,4 +25,6 @@ Gem::Specification.new do |gem|
   gem.add_development_dependency 'rspec', '~> 3.5'
   gem.add_development_dependency 'rake'
   gem.add_development_dependency 'simplecov'
+  gem.add_development_dependency 'guard'
+  gem.add_development_dependency 'guard-rspec'
 end

--- a/spec/rdkafka/producer_spec.rb
+++ b/spec/rdkafka/producer_spec.rb
@@ -1,4 +1,5 @@
 require "spec_helper"
+require "zlib"
 
 describe Rdkafka::Producer do
   let(:producer) { rdkafka_producer_config.producer }

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -105,6 +105,9 @@ def wait_for_unassignment(consumer)
 end
 
 RSpec.configure do |config|
+  config.filter_run focus: true
+  config.run_all_when_everything_filtered = true
+
   config.before(:suite) do
     admin = rdkafka_config.admin
     {

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -8,7 +8,6 @@ end
 require "pry"
 require "rspec"
 require "rdkafka"
-require "zlib"
 require "timeout"
 
 def rdkafka_base_config


### PR DESCRIPTION
This extract `Guard` setup and rspec `focus` settings from #172.

This also cherry-picks the `zlib` require to fix a spec.
As this was fixed on main, the require here is move to the only spec that needs it, potentially improving test suite speed.