### PR TITLE
Fix spec setup

### DIFF
--- a/lib/rdkafka/admin.rb
+++ b/lib/rdkafka/admin.rb
@@ -90,7 +90,7 @@ module Rdkafka
             admin_options_ptr,
             queue_ptr
         )
-      rescue Exception => err
+      rescue Exception
         CreateTopicHandle.remove(create_topic_handle.to_ptr.address)
         raise
       ensure
@@ -140,7 +140,7 @@ module Rdkafka
             admin_options_ptr,
             queue_ptr
         )
-      rescue Exception => err
+      rescue Exception
         DeleteTopicHandle.remove(delete_topic_handle.to_ptr.address)
         raise
       ensure

--- a/spec/rdkafka/consumer_spec.rb
+++ b/spec/rdkafka/consumer_spec.rb
@@ -241,7 +241,7 @@ describe Rdkafka::Consumer do
 
     it "should return the assignment when subscribed" do
       # Make sure there's a message
-      report = producer.produce(
+      producer.produce(
         topic:     "consume_test_topic",
         payload:   "payload 1",
         key:       "key 1",
@@ -272,7 +272,7 @@ describe Rdkafka::Consumer do
     it "should close a consumer" do
       consumer.subscribe("consume_test_topic")
       100.times do |i|
-        report = producer.produce(
+        producer.produce(
           topic:     "consume_test_topic",
           payload:   "payload #{i}",
           key:       "key #{i}",
@@ -289,7 +289,7 @@ describe Rdkafka::Consumer do
   describe "#commit, #committed and #store_offset" do
     # Make sure there's a stored offset
     let!(:report) do
-      report = producer.produce(
+      producer.produce(
         topic:     "consume_test_topic",
         payload:   "payload 1",
         key:       "key 1",
@@ -831,7 +831,6 @@ describe Rdkafka::Consumer do
         )
         consumer = config.consumer
         consumer.subscribe(topic_name)
-        loop_count = 0
         batches_yielded = []
         exceptions_yielded = []
         each_batch_iterations = 0
@@ -875,7 +874,6 @@ describe Rdkafka::Consumer do
         )
         consumer = config.consumer
         consumer.subscribe(topic_name)
-        loop_count = 0
         batches_yielded = []
         exceptions_yielded = []
         each_batch_iterations = 0

--- a/spec/rdkafka/producer/client_spec.rb
+++ b/spec/rdkafka/producer/client_spec.rb
@@ -1,15 +1,16 @@
 require "spec_helper"
 
 describe Rdkafka::Producer::Client do
-  let(:native) { double }
+  let(:config) { rdkafka_producer_config }
+  let(:native) { config.send(:native_kafka, config.send(:native_config), :rd_kafka_producer) }
   let(:closing) { false }
   let(:thread) { double(Thread) }
 
   subject(:client) { described_class.new(native) }
 
   before do
-    allow(Rdkafka::Bindings).to receive(:rd_kafka_poll).with(native, 250)
-    allow(Rdkafka::Bindings).to receive(:rd_kafka_outq_len).with(native).and_return(0)
+    allow(Rdkafka::Bindings).to receive(:rd_kafka_poll).with(instance_of(FFI::Pointer), 250).and_call_original
+    allow(Rdkafka::Bindings).to receive(:rd_kafka_outq_len).with(instance_of(FFI::Pointer)).and_return(0).and_call_original
     allow(Rdkafka::Bindings).to receive(:rd_kafka_destroy)
     allow(Thread).to receive(:new).and_return(thread)
 
@@ -41,7 +42,7 @@ describe Rdkafka::Producer::Client do
 
     it "polls the native with default 250ms timeout" do
       polling_loop_expects do
-        expect(Rdkafka::Bindings).to receive(:rd_kafka_poll).with(native, 250)
+        expect(Rdkafka::Bindings).to receive(:rd_kafka_poll).with(instance_of(FFI::Pointer), 250)
       end
     end
 

--- a/spec/rdkafka/producer_spec.rb
+++ b/spec/rdkafka/producer_spec.rb
@@ -376,13 +376,9 @@ describe Rdkafka::Producer do
     end
   end
 
-  it "should produce a message in a forked process" do
+  it "should produce a message in a forked process", skip: defined?(JRUBY_VERSION) && "Kernel#fork is not available" do
     # Fork, produce a message, send the report over a pipe and
     # wait for and check the message in the main process.
-
-    # Kernel#fork is not available in JRuby
-    skip if defined?(JRUBY_VERSION)
-
     reader, writer = IO.pipe
 
     fork do


### PR DESCRIPTION
This fixes some test setup that used mock but ended up not covering some inner dependencies. The mocks were changed back to real object.

This also removes some unused variables shown as warning by the linter.