### PR TITLE
Revert "Use RUBYARCHDIR for library location if present"

### DIFF
--- a/ext/Rakefile
+++ b/ext/Rakefile
@@ -28,25 +28,16 @@ task :default => :clean do
     from_extension = 'so.1'
     to_extension = 'so'
   end
-
-  # Get path to the compiled library
   lib_path = File.join(File.dirname(__FILE__), "ports/#{recipe.host}/librdkafka/#{Rdkafka::LIBRDKAFKA_VERSION}/lib/librdkafka.#{from_extension}")
-
-  # Get target dir
-  target_dir = ENV["RUBYARCHDIR"] || File.dirname(__FILE__)
-
-  # Move the compliled library there
-  FileUtils.mv(lib_path, File.join(target_dir, "librdkafka.#{to_extension}"))
-
+  FileUtils.mv(lib_path, File.join(File.dirname(__FILE__), "librdkafka.#{to_extension}"))
   # Cleanup files created by miniportile we don't need in the gem
-  FileUtils.rm_rf File.join(target_dir, "tmp")
-  FileUtils.rm_rf File.join(target_dir, "ports")
+  FileUtils.rm_rf File.join(File.dirname(__FILE__), "tmp")
+  FileUtils.rm_rf File.join(File.dirname(__FILE__), "ports")
 end
 
 task :clean do
-  target_dir = ENV["RUBYARCHDIR"] || File.dirname(__FILE__)
-  FileUtils.rm_f File.join(target_dir, "librdkafka.dylib")
-  FileUtils.rm_f File.join(target_dir, "librdkafka.so")
+  FileUtils.rm_f File.join(File.dirname(__FILE__), "librdkafka.dylib")
+  FileUtils.rm_f File.join(File.dirname(__FILE__), "librdkafka.so")
   FileUtils.rm_rf File.join(File.dirname(__FILE__), "ports")
   FileUtils.rm_rf File.join(File.dirname(__FILE__), "tmp")
 end


### PR DESCRIPTION
Reverts appsignal/rdkafka-ruby#191

We currently use a relative path in our bindings file
https://github.com/appsignal/rdkafka-ruby/blob/d973708d89dab78330f2609793262113e1d1430a/lib/rdkafka/bindings.rb#L18 in order to load the library. We need to change how we load the library in order to be able to publish the C extension in the `RUBYARCHDIR` directory.

The current release is broken, so in order to fix it I'm reverting this PR for now.