### PR TITLE
Pass the delivery handle to the callback

### DIFF
--- a/lib/rdkafka/callbacks.rb
+++ b/lib/rdkafka/callbacks.rb
@@ -97,7 +97,7 @@ module Rdkafka
           delivery_handle[:pending] = false
           # Call delivery callback on opaque
           if opaque = Rdkafka::Config.opaques[opaque_ptr.to_i]
-            opaque.call_delivery_callback(Rdkafka::Producer::DeliveryReport.new(message[:partition], message[:offset], message[:err]))
+            opaque.call_delivery_callback(Rdkafka::Producer::DeliveryReport.new(message[:partition], message[:offset], message[:err]), delivery_handle)
           end
         end
       end

--- a/lib/rdkafka/config.rb
+++ b/lib/rdkafka/config.rb
@@ -278,8 +278,8 @@ module Rdkafka
     attr_accessor :producer
     attr_accessor :consumer_rebalance_listener
 
-    def call_delivery_callback(delivery_handle)
-      producer.call_delivery_callback(delivery_handle) if producer
+    def call_delivery_callback(delivery_report, delivery_handle)
+      producer.call_delivery_callback(delivery_report, delivery_handle) if producer
     end
 
     def call_on_partitions_assigned(consumer, list)

--- a/spec/rdkafka/producer_spec.rb
+++ b/spec/rdkafka/producer_spec.rb
@@ -116,17 +116,17 @@ describe Rdkafka::Producer do
       end
 
       it "should provide handle" do
-        callback_handle = []
+        callback_handles = []
         callback = Class.new do
-          def initialize(callback_handle)
-            @callback_handle = callback_handle
+          def initialize(callback_handles)
+            @callback_handles = callback_handles
           end
 
           def call(_, handle)
-            @callback_handle << handle
+            @callback_handles << handle
           end
         end
-        producer.delivery_callback = callback.new(callback_handle)
+        producer.delivery_callback = callback.new(callback_handles)
 
         # Produce a message
         handle = producer.produce(
@@ -142,7 +142,7 @@ describe Rdkafka::Producer do
         producer.close
 
         # Callback should have been called
-        expect(handle).to be callback_handle.first
+        expect(handle).to be callback_handles.first
       end
     end
 


### PR DESCRIPTION
Added a small improvement to the producer that allows configuring callbacks that accept delivery handles as a second parameter to the callback. 

This is intended to address the issue described in https://github.com/appsignal/rdkafka-ruby/issues/195. Had to address some issues with callback arity to make this fully backwards compatible. 