### PR TITLE
Issue #168/string keys for consumer message headers

### DIFF
--- a/lib/rdkafka/bindings.rb
+++ b/lib/rdkafka/bindings.rb
@@ -17,7 +17,7 @@ module Rdkafka
       end
     end
 
-    ffi_lib File.join(File.dirname(__FILE__), "../../ext/librdkafka.#{lib_extension}")
+    ffi_lib File.join(__dir__, "../../ext/librdkafka.#{lib_extension}")
 
     RD_KAFKA_RESP_ERR__ASSIGN_PARTITIONS = -175
     RD_KAFKA_RESP_ERR__REVOKE_PARTITIONS = -174

--- a/lib/rdkafka/consumer/headers.rb
+++ b/lib/rdkafka/consumer/headers.rb
@@ -53,7 +53,7 @@ module Rdkafka
 
           value = value_ptr.read_string(size)
 
-          headers[name.to_sym] = value
+          headers[name] = value
 
           idx += 1
         end

--- a/lib/rdkafka/consumer/headers.rb
+++ b/lib/rdkafka/consumer/headers.rb
@@ -4,10 +4,15 @@ module Rdkafka
   class Consumer
     # Interface to return headers for a consumer message
     module Headers
-      class HashWithOnlyStringKeysAllowed < Hash
+      class HashWithSymbolKeysTreatedLikeStrings < Hash
         def [](key)
-          key.is_a?(String) or raise ArgumentError, "rdkafka headers keys must be Strings; got #{key.inspect}"
-          super
+          if key.is_a?(Symbol)
+            Kernel.warn("rdkafka deprecation warning: header access with Symbol key #{key.inspect} treated as a String. " \
+                        "Please change your code to use String keys to avoid this warning. Symbol keys will break in version 1.")
+            super(key.to_s)
+          else
+            super
+          end
         end
       end
 
@@ -36,7 +41,7 @@ module Rdkafka
         value_ptrptr = FFI::MemoryPointer.new(:pointer)
         size_ptr = Rdkafka::Bindings::SizePtr.new
 
-        headers = HashWithOnlyStringKeysAllowed.new
+        headers = HashWithSymbolKeysTreatedLikeStrings.new
 
         idx = 0
         loop do

--- a/lib/rdkafka/consumer/headers.rb
+++ b/lib/rdkafka/consumer/headers.rb
@@ -4,6 +4,13 @@ module Rdkafka
   class Consumer
     # Interface to return headers for a consumer message
     module Headers
+      class HashWithOnlyStringKeysAllowed < Hash
+        def [](key)
+          key.is_a?(String) or raise ArgumentError, "rdkafka headers keys must be Strings; got #{key.inspect}"
+          super
+        end
+      end
+
       # Reads a librdkafka native message's headers and returns them as a Ruby Hash
       #
       # @param [librdkakfa message] native_message
@@ -28,7 +35,8 @@ module Rdkafka
         name_ptrptr = FFI::MemoryPointer.new(:pointer)
         value_ptrptr = FFI::MemoryPointer.new(:pointer)
         size_ptr = Rdkafka::Bindings::SizePtr.new
-        headers = {}
+
+        headers = HashWithOnlyStringKeysAllowed.new
 
         idx = 0
         loop do
@@ -60,7 +68,7 @@ module Rdkafka
           idx += 1
         end
 
-        headers
+        headers.freeze
       end
     end
   end

--- a/lib/rdkafka/consumer/headers.rb
+++ b/lib/rdkafka/consumer/headers.rb
@@ -2,11 +2,13 @@
 
 module Rdkafka
   class Consumer
-    # A message headers
+    # Interface to return headers for a consumer message
     module Headers
-      # Reads a native kafka's message header into ruby's hash
+      # Reads a librdkafka native message's headers and returns them as a Ruby Hash
       #
-      # @return [Hash<String, String>] a message headers
+      # @param [librdkakfa message] native_message
+      #
+      # @return [Hash<String, String>] headers Hash for the native_message
       #
       # @raise [Rdkafka::RdkafkaError] when fail to read headers
       #

--- a/lib/rdkafka/consumer/headers.rb
+++ b/lib/rdkafka/consumer/headers.rb
@@ -3,7 +3,7 @@
 module Rdkafka
   class Consumer
     # A message headers
-    class Headers
+    module Headers
       # Reads a native kafka's message header into ruby's hash
       #
       # @return [Hash<String, String>] a message headers

--- a/lib/rdkafka/consumer/message.rb
+++ b/lib/rdkafka/consumer/message.rb
@@ -20,7 +20,7 @@ module Rdkafka
       # @return [String, nil]
       attr_reader :key
 
-      # This message's offset in it's partition
+      # This message's offset in its partition
       # @return [Integer]
       attr_reader :offset
 

--- a/spec/rdkafka/consumer/headers_spec.rb
+++ b/spec/rdkafka/consumer/headers_spec.rb
@@ -52,9 +52,11 @@ describe Rdkafka::Consumer::Headers do
       expect(subject['version']).to eq("2.1.3")
     end
 
-    it 'raises an exception on Symbol key attempt' do
-      expect { subject[:version] }.to \
-        raise_exception(ArgumentError, "rdkafka headers keys must be Strings; got :version")
+    it 'allows Symbol key, but warns' do
+      expect(Kernel).to \
+        receive(:warn).with("rdkafka deprecation warning: header access with Symbol key :version treated as a String. " \
+                            "Please change your code to use String keys to avoid this warning. Symbol keys will break in version 1.")
+      expect(subject[:version]).to eq("2.1.3")
     end
   end
 end

--- a/spec/rdkafka/consumer/headers_spec.rb
+++ b/spec/rdkafka/consumer/headers_spec.rb
@@ -49,7 +49,7 @@ describe Rdkafka::Consumer::Headers do
     it { is_expected.to be_frozen }
 
     it 'allows String key' do
-      expect(subject['version']).to eq(headers.values[0])
+      expect(subject['version']).to eq("2.1.3")
     end
 
     it 'raises an exception on Symbol key attempt' do

--- a/spec/rdkafka/consumer/headers_spec.rb
+++ b/spec/rdkafka/consumer/headers_spec.rb
@@ -1,0 +1,50 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+
+describe Rdkafka::Consumer::Headers do
+  let(:headers) do
+    { # Note String keys!
+      "version" => "2.1.3",
+      "type" => "String"
+    }
+  end
+  let(:native_message) { double('native message') }
+  let(:headers_ptr) { double('headers pointer') }
+
+  describe '.from_native' do
+    before do
+      expect(Rdkafka::Bindings).to receive(:rd_kafka_message_headers).with(native_message, anything) do |_, headers_ptrptr|
+        expect(headers_ptrptr).to receive(:read_pointer).and_return(headers_ptr)
+        Rdkafka::Bindings::RD_KAFKA_RESP_ERR_NO_ERROR
+      end
+
+      expect(Rdkafka::Bindings).to \
+        receive(:rd_kafka_header_get_all)
+          .with(headers_ptr, 0, anything, anything, anything) do |_, _, name_ptrptr, value_ptrptr, size_ptr|
+              expect(name_ptrptr).to receive(:read_pointer).and_return(double("pointer 0", read_string_to_null: headers.keys[0]))
+              expect(size_ptr).to receive(:[]).with(:value).and_return(headers.keys[0].size)
+              expect(value_ptrptr).to receive(:read_pointer).and_return(double("value pointer 0", read_string: headers.values[0]))
+              Rdkafka::Bindings::RD_KAFKA_RESP_ERR_NO_ERROR
+            end
+
+      expect(Rdkafka::Bindings).to \
+        receive(:rd_kafka_header_get_all)
+          .with(headers_ptr, 1, anything, anything, anything) do |_, _, name_ptrptr, value_ptrptr, size_ptr|
+              expect(name_ptrptr).to receive(:read_pointer).and_return(double("pointer 1", read_string_to_null: headers.keys[1]))
+              expect(size_ptr).to receive(:[]).with(:value).and_return(headers.keys[1].size)
+              expect(value_ptrptr).to receive(:read_pointer).and_return(double("value pointer 1", read_string: headers.values[1]))
+              Rdkafka::Bindings::RD_KAFKA_RESP_ERR_NO_ERROR
+            end
+
+      expect(Rdkafka::Bindings).to \
+        receive(:rd_kafka_header_get_all)
+          .with(headers_ptr, 2, anything, anything, anything)
+          .and_return(Rdkafka::Bindings::RD_KAFKA_RESP_ERR__NOENT)
+    end
+
+    subject { described_class.from_native(native_message) }
+
+    it { is_expected.to eq(headers) }
+  end
+end

--- a/spec/rdkafka/consumer/headers_spec.rb
+++ b/spec/rdkafka/consumer/headers_spec.rb
@@ -46,5 +46,15 @@ describe Rdkafka::Consumer::Headers do
     subject { described_class.from_native(native_message) }
 
     it { is_expected.to eq(headers) }
+    it { is_expected.to be_frozen }
+
+    it 'allows String key' do
+      expect(subject['version']).to eq(headers.values[0])
+    end
+
+    it 'raises an exception on Symbol key attempt' do
+      expect { subject[:version] }.to \
+        raise_exception(ArgumentError, "rdkafka headers keys must be Strings; got :version")
+    end
   end
 end

--- a/spec/rdkafka/consumer_spec.rb
+++ b/spec/rdkafka/consumer_spec.rb
@@ -595,7 +595,7 @@ describe Rdkafka::Consumer do
   end
 
   describe "#poll with headers" do
-    it "should return message with headers" do
+    it "should return message with headers using string keys (when produced with symbol keys)" do
       report = producer.produce(
         topic:     "consume_test_topic",
         key:       "key headers",
@@ -605,7 +605,20 @@ describe Rdkafka::Consumer do
       message = wait_for_message(topic: "consume_test_topic", consumer: consumer, delivery_report: report)
       expect(message).to be
       expect(message.key).to eq('key headers')
-      expect(message.headers).to include(foo: 'bar')
+      expect(message.headers).to include('foo' => 'bar')
+    end
+
+    it "should return message with headers using string keys (when produced with string keys)" do
+      report = producer.produce(
+        topic:     "consume_test_topic",
+        key:       "key headers",
+        headers:   { 'foo' => 'bar' }
+      ).wait
+
+      message = wait_for_message(topic: "consume_test_topic", consumer: consumer, delivery_report: report)
+      expect(message).to be
+      expect(message.key).to eq('key headers')
+      expect(message.headers).to include('foo' => 'bar')
     end
 
     it "should return message with no headers" do

--- a/spec/rdkafka/producer_spec.rb
+++ b/spec/rdkafka/producer_spec.rb
@@ -406,9 +406,9 @@ describe Rdkafka::Producer do
 
     expect(message.payload).to eq "payload headers"
     expect(message.key).to eq "key headers"
-    expect(message.headers[:foo]).to eq "bar"
-    expect(message.headers[:baz]).to eq "foobar"
-    expect(message.headers[:foobar]).to be_nil
+    expect(message.headers['foo']).to eq "bar"
+    expect(message.headers['baz']).to eq "foobar"
+    expect(message.headers['foobar']).to be_nil
   end
 
   it "should produce a message with empty headers" do

--- a/spec/rdkafka/producer_spec.rb
+++ b/spec/rdkafka/producer_spec.rb
@@ -187,7 +187,7 @@ describe Rdkafka::Producer do
     # Close producer
     producer.close
 
-    # Consume message and verify it's content
+    # Consume message and verify its content
     message = wait_for_message(
       topic: "produce_test_topic",
       delivery_report: report,
@@ -211,7 +211,7 @@ describe Rdkafka::Producer do
     )
     report = handle.wait(max_wait_timeout: 5)
 
-    # Consume message and verify it's content
+    # Consume message and verify its content
     message = wait_for_message(
       topic: "produce_test_topic",
       delivery_report: report,
@@ -285,7 +285,7 @@ describe Rdkafka::Producer do
     )
     report = handle.wait(max_wait_timeout: 5)
 
-    # Consume message and verify it's content
+    # Consume message and verify its content
     message = wait_for_message(
       topic: "produce_test_topic",
       delivery_report: report,
@@ -318,7 +318,7 @@ describe Rdkafka::Producer do
       )
       report = handle.wait(max_wait_timeout: 5)
 
-      # Consume message and verify it's content
+      # Consume message and verify its content
       message = wait_for_message(
         topic: "produce_test_topic",
         delivery_report: report,
@@ -339,7 +339,7 @@ describe Rdkafka::Producer do
       )
       report = handle.wait(max_wait_timeout: 5)
 
-      # Consume message and verify it's content
+      # Consume message and verify its content
       message = wait_for_message(
         topic: "produce_test_topic",
         delivery_report: report,
@@ -359,7 +359,7 @@ describe Rdkafka::Producer do
     )
     report = handle.wait(max_wait_timeout: 5)
 
-    # Consume message and verify it's content
+    # Consume message and verify its content
     message = wait_for_message(
       topic: "produce_test_topic",
       delivery_report: report,
@@ -377,7 +377,7 @@ describe Rdkafka::Producer do
     )
     report = handle.wait(max_wait_timeout: 5)
 
-    # Consume message and verify it's content
+    # Consume message and verify its content
     message = wait_for_message(
       topic: "produce_test_topic",
       delivery_report: report,
@@ -397,7 +397,7 @@ describe Rdkafka::Producer do
     )
     report = handle.wait(max_wait_timeout: 5)
 
-    # Consume message and verify it's content
+    # Consume message and verify its content
     message = wait_for_message(
       topic: "produce_test_topic",
       delivery_report: report,
@@ -420,7 +420,7 @@ describe Rdkafka::Producer do
     )
     report = handle.wait(max_wait_timeout: 5)
 
-    # Consume message and verify it's content
+    # Consume message and verify its content
     message = wait_for_message(
       topic: "produce_test_topic",
       delivery_report: report,
@@ -493,7 +493,7 @@ describe Rdkafka::Producer do
 
     reader.close
 
-    # Consume message and verify it's content
+    # Consume message and verify its content
     message = wait_for_message(
       topic: "produce_test_topic",
       delivery_report: report,

--- a/spec/rdkafka/producer_spec.rb
+++ b/spec/rdkafka/producer_spec.rb
@@ -9,7 +9,7 @@ describe Rdkafka::Producer do
 
   after do
     # Registry should always end up being empty
-    expect(Rdkafka::Producer::DeliveryHandle::REGISTRY).to eq({})
+    expect(Rdkafka::Producer::DeliveryHandle::REGISTRY).to be_empty
     producer.close
     consumer.close
   end

--- a/spec/rdkafka/producer_spec.rb
+++ b/spec/rdkafka/producer_spec.rb
@@ -9,7 +9,8 @@ describe Rdkafka::Producer do
 
   after do
     # Registry should always end up being empty
-    expect(Rdkafka::Producer::DeliveryHandle::REGISTRY).to be_empty
+    registry = Rdkafka::Producer::DeliveryHandle::REGISTRY
+    expect(registry).to be_empty, registry.inspect
     producer.close
     consumer.close
   end

--- a/spec/rdkafka/producer_spec.rb
+++ b/spec/rdkafka/producer_spec.rb
@@ -406,9 +406,9 @@ describe Rdkafka::Producer do
 
     expect(message.payload).to eq "payload headers"
     expect(message.key).to eq "key headers"
-    expect(message.headers['foo']).to eq "bar"
-    expect(message.headers['baz']).to eq "foobar"
-    expect(message.headers['foobar']).to be_nil
+    expect(message.headers["foo"]).to eq "bar"
+    expect(message.headers["baz"]).to eq "foobar"
+    expect(message.headers["foobar"]).to be_nil
   end
 
   it "should produce a message with empty headers" do


### PR DESCRIPTION
Addresses issue #168:
- Change `Headers` to return `Hash<String, String>` as documented, starting with corresponding spec change.
- Rdoc updates.

These simplifications are also included:
- Change `Headers` to a `Module` since it is only a namespace and not a `Class`.
- Use `__dir__` for the directory of the current `__FILE__`.

Note: this is a breaking change since any code that is reading the `headers` today with symbols will need to change to strings. Because the version number starts with `0.`, Sem Ver doesn't require a major version bump. But we should advertise it broadly and at least do a minor version bump.
