### PR TITLE
Include topic name in delivery report

### DIFF
--- a/lib/rdkafka/producer/delivery_handle.rb
+++ b/lib/rdkafka/producer/delivery_handle.rb
@@ -8,7 +8,8 @@ module Rdkafka
       layout :pending, :bool,
              :response, :int,
              :partition, :int,
-             :offset, :int64
+             :offset, :int64,
+             :topic_name, :pointer
 
       # @return [String] the name of the operation (e.g. "delivery")
       def operation_name
@@ -17,7 +18,7 @@ module Rdkafka
 
       # @return [DeliveryReport] a report on the delivery of the message
       def create_result
-        DeliveryReport.new(self[:partition], self[:offset])
+        DeliveryReport.new(self[:partition], self[:offset], self[:topic_name].read_string)
       end
     end
   end

--- a/lib/rdkafka/producer/delivery_report.rb
+++ b/lib/rdkafka/producer/delivery_report.rb
@@ -12,15 +12,20 @@ module Rdkafka
       # @return [Integer]
       attr_reader :offset
 
+      # The name of the topic this message was produced to.
+      # @return [String]
+      attr_reader :topic_name
+
       # Error in case happen during produce.
       # @return [String]
       attr_reader :error
 
       private
 
-      def initialize(partition, offset, error = nil)
+      def initialize(partition, offset, topic_name = nil, error = nil)
         @partition = partition
         @offset = offset
+        @topic_name = topic_name
         @error = error
       end
     end

--- a/spec/rdkafka/producer/delivery_handle_spec.rb
+++ b/spec/rdkafka/producer/delivery_handle_spec.rb
@@ -11,6 +11,7 @@ describe Rdkafka::Producer::DeliveryHandle do
       handle[:response] = response
       handle[:partition] = 2
       handle[:offset] = 100
+      handle[:topic_name] = FFI::MemoryPointer.from_string("produce_test_topic")
     end
   end
 
@@ -31,6 +32,7 @@ describe Rdkafka::Producer::DeliveryHandle do
 
         expect(report.partition).to eq(2)
         expect(report.offset).to eq(100)
+        expect(report.topic_name).to eq("produce_test_topic")
       end
 
       it "should wait without a timeout" do
@@ -38,6 +40,7 @@ describe Rdkafka::Producer::DeliveryHandle do
 
         expect(report.partition).to eq(2)
         expect(report.offset).to eq(100)
+        expect(report.topic_name).to eq("produce_test_topic")
       end
     end
   end

--- a/spec/rdkafka/producer/delivery_report_spec.rb
+++ b/spec/rdkafka/producer/delivery_report_spec.rb
@@ -3,7 +3,7 @@
 require "spec_helper"
 
 describe Rdkafka::Producer::DeliveryReport do
-  subject { Rdkafka::Producer::DeliveryReport.new(2, 100, "error") }
+  subject { Rdkafka::Producer::DeliveryReport.new(2, 100, "topic", "error") }
 
   it "should get the partition" do
     expect(subject.partition).to eq 2
@@ -11,6 +11,10 @@ describe Rdkafka::Producer::DeliveryReport do
 
   it "should get the offset" do
     expect(subject.offset).to eq 100
+  end
+
+  it "should get the topic_name" do
+    expect(subject.topic_name).to eq "topic"
   end
 
   it "should get the error" do

--- a/spec/rdkafka/producer_spec.rb
+++ b/spec/rdkafka/producer_spec.rb
@@ -32,6 +32,7 @@ describe Rdkafka::Producer do
           expect(report).not_to be_nil
           expect(report.partition).to eq 1
           expect(report.offset).to be >= 0
+          expect(report.topic_name).to eq "produce_test_topic"
           @callback_called = true
         end
 
@@ -115,6 +116,7 @@ describe Rdkafka::Producer do
         expect(called_report.first).not_to be_nil
         expect(called_report.first.partition).to eq 1
         expect(called_report.first.offset).to be >= 0
+        expect(called_report.first.topic_name).to eq "produce_test_topic"
       end
 
       it "should provide handle" do
@@ -472,7 +474,8 @@ describe Rdkafka::Producer do
 
       report_json = JSON.generate(
         "partition" => report.partition,
-        "offset" => report.offset
+        "offset" => report.offset,
+        "topic_name" => report.topic_name
       )
 
       writer.write(report_json)
@@ -484,7 +487,8 @@ describe Rdkafka::Producer do
     report_hash = JSON.parse(reader.read)
     report = Rdkafka::Producer::DeliveryReport.new(
       report_hash["partition"],
-      report_hash["offset"]
+      report_hash["offset"],
+      report_hash["topic_name"]
     )
 
     reader.close


### PR DESCRIPTION
I want to be able to access the topic name inside a delivery callback, but the delivery report only includes the partition and offset for the delivered message. The underlying dr_msg_cb in librdkafka has access to the message with topic, so this PR introduces changes to pull the topic name from there.