### PR TITLE
Handle tombstone event

### DIFF
--- a/lib/rdkafka/consumer.rb
+++ b/lib/rdkafka/consumer.rb
@@ -550,7 +550,7 @@ module Rdkafka
         end
         if message
           slice << message
-          bytes += message.payload.bytesize
+          bytes += message.payload.bytesize if message.payload
         end
         if slice.size == max_items || bytes >= bytes_threshold || monotonic_now >= end_time - 0.001
           yield slice.dup, nil

--- a/spec/rdkafka/consumer_spec.rb
+++ b/spec/rdkafka/consumer_spec.rb
@@ -74,7 +74,7 @@ describe Rdkafka::Consumer do
         consumer.commit
 
         # 4. send a second message
-        send_one_message
+        send_tombstone_event
 
         # 5. pause the subscription
         tpl = Rdkafka::Consumer::TopicPartitionList.new
@@ -124,6 +124,14 @@ describe Rdkafka::Consumer do
       producer.produce(
         topic:     "consume_test_topic",
         payload:   "payload 1",
+        key:       "key 1"
+      ).wait
+    end
+
+    def send_tombstone_event
+      producer.produce(
+        topic:     "consume_test_topic",
+        payload:   nil,
         key:       "key 1"
       ).wait
     end

--- a/spec/rdkafka/consumer_spec.rb
+++ b/spec/rdkafka/consumer_spec.rb
@@ -74,7 +74,7 @@ describe Rdkafka::Consumer do
         consumer.commit
 
         # 4. send a second message
-        send_tombstone_event
+        send_one_message
 
         # 5. pause the subscription
         tpl = Rdkafka::Consumer::TopicPartitionList.new
@@ -124,14 +124,6 @@ describe Rdkafka::Consumer do
       producer.produce(
         topic:     "consume_test_topic",
         payload:   "payload 1",
-        key:       "key 1"
-      ).wait
-    end
-
-    def send_tombstone_event
-      producer.produce(
-        topic:     "consume_test_topic",
-        payload:   nil,
         key:       "key 1"
       ).wait
     end
@@ -708,7 +700,7 @@ describe Rdkafka::Consumer do
       n.times do |i|
         handles << producer.produce(
           topic:     topic_name,
-          payload:   Time.new.to_f.to_s,
+          payload:   i % 10 == 0 ? nil : Time.new.to_f.to_s,
           key:       i.to_s,
           partition: 0
         )


### PR DESCRIPTION
Fixes 
```
bundler: failed to load command: bin/avro-example (bin/avro-example)
/Users/lourens/.gem/ruby/3.1.2/gems/rdkafka-0.12.0/lib/rdkafka/consumer.rb:548:in `block in each_batch': undefined method `bytesize' for nil:NilClass (NoMethodError)

          bytes += message.payload.bytesize
                                  ^^^^^^^^^
	from /Users/lourens/.gem/ruby/3.1.2/gems/rdkafka-0.12.0/lib/rdkafka/consumer.rb:529:in `loop'
	from /Users/lourens/.gem/ruby/3.1.2/gems/rdkafka-0.12.0/lib/rdkafka/consumer.rb:529:in `each_batch'
```