### PR TITLE
Fix documented type for `DeliveryReport#error`

### DIFF
--- a/lib/rdkafka/producer/delivery_report.rb
+++ b/lib/rdkafka/producer/delivery_report.rb
@@ -17,7 +17,7 @@ module Rdkafka
       attr_reader :topic_name
 
       # Error in case happen during produce.
-      # @return [String]
+      # @return [Integer]
       attr_reader :error
 
       private

--- a/spec/rdkafka/producer/delivery_report_spec.rb
+++ b/spec/rdkafka/producer/delivery_report_spec.rb
@@ -3,7 +3,7 @@
 require "spec_helper"
 
 describe Rdkafka::Producer::DeliveryReport do
-  subject { Rdkafka::Producer::DeliveryReport.new(2, 100, "topic", "error") }
+  subject { Rdkafka::Producer::DeliveryReport.new(2, 100, "topic", -1) }
 
   it "should get the partition" do
     expect(subject.partition).to eq 2
@@ -18,6 +18,6 @@ describe Rdkafka::Producer::DeliveryReport do
   end
 
   it "should get the error" do
-    expect(subject.error).to eq "error"
+    expect(subject.error).to eq -1
   end
 end


### PR DESCRIPTION
I also updated the spec to be consistent with the updated type.