### PR TITLE
Support the incremental partition assign and unassign APIs for the cooperative rebalancing protocol when a rebalance listener is set

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+# 0.13.0
+* Supports cooperative sticky partition assignment in the rebalance callback (methodmissing)
+
 # 0.12.0
 * Bumps librdkafka to 1.9.0
 * Fix crash on empty partition key (mensfeld)

--- a/lib/rdkafka/version.rb
+++ b/lib/rdkafka/version.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 module Rdkafka
-  VERSION = "0.12.0"
+  VERSION = "0.13.0"
   LIBRDKAFKA_VERSION = "1.9.0"
   LIBRDKAFKA_SOURCE_SHA256 = "59b6088b69ca6cf278c3f9de5cd6b7f3fd604212cd1c59870bc531c54147e889"
 end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -106,6 +106,20 @@ def wait_for_unassignment(consumer)
   end
 end
 
+def notify_listener(listener, &block)
+  # 1. subscribe and poll
+  consumer.subscribe("consume_test_topic")
+  wait_for_assignment(consumer)
+  consumer.poll(100)
+
+  block.call if block
+
+  # 2. unsubscribe
+  consumer.unsubscribe
+  wait_for_unassignment(consumer)
+  consumer.close
+end
+
 RSpec.configure do |config|
   config.filter_run focus: true
   config.run_all_when_everything_filtered = true


### PR DESCRIPTION
## Problem

When setting `partition.assignment.strategy` to `cooperative-sticky`, we observed the following error in logs as a warning (and the consumer made 0 progress as no partitions are assigned):

`W, [2022-10-03T11:02:55.219884 #65446]  WARN -- : rdkafka: [thrd:main]: Group "foo": application *assign() call failed: Changes to the current assignment must be made using incremental_assign() or incremental_unassign()`

Upon further investigation we realised that special API's are [required to be called](https://github.com/edenhill/librdkafka/blob/b871fdabab84b2ea1be3866a2ded4def7e31b006/src-cpp/rdkafkacpp.h#L971-L982):

```
   * For eager/non-cooperative `partition.assignment.strategy` assignors,
   * such as `range` and `roundrobin`, the application must use
   * assign assign() to set and unassign() to clear the entire assignment.
   * For the cooperative assignors, such as `cooperative-sticky`, the
   * application must use incremental_assign() for ERR__ASSIGN_PARTITIONS and
   * incremental_unassign() for ERR__REVOKE_PARTITIONS.
   *
   * Without a rebalance callback this is done automatically by librdkafka
   * but registering a rebalance callback gives the application flexibility
   * in performing other operations along with the assinging/revocation,
   * such as fetching offsets from an alternate location (on assign)
   * or manually committing offsets (on revoke).
```

Those are:

* `rd_kafka_rebalance_protocol` (to query the effective rebalance protocol)
* `rd_kafka_incremental_assign` (to be called when partitions are assigned)
* `rd_kafka_incremental_unassign` (to be called when partitions are revoked)

This ☝️ is true only for when a rebalance callback is registered, otherwise `librdkafka` will do the right thing ™️ 

## The implementation

* Added support for the above APIs (`rd_kafka_rebalance_protocol`, `rd_kafka_incremental_assign` and `rd_kafka_incremental_unassign`)
* Conditionally call the correct assignment APIs on events `RD_KAFKA_RESP_ERR__ASSIGN_PARTITIONS` and `RD_KAFKA_RESP_ERR__REVOKE_PARTITIONS` depending on the rebalancing protocol in effect
* Implemented a test case for `partition.assignment.strategy=coperative-sticky` which would just hang otherwise and throw warning `rdkafka: [thrd:main]: Group "foo": application *assign() call failed: Changes to the current assignment must be made using incremental_assign() or incremental_unassign()`

cc @bdbene @kgalieva