### PR TITLE
Remove blocking flag for poll and close

### DIFF
--- a/lib/rdkafka/bindings.rb
+++ b/lib/rdkafka/bindings.rb
@@ -36,8 +36,8 @@ module Rdkafka
     # Polling
 
     attach_function :rd_kafka_flush, [:pointer, :int], :void, blocking: true
-    attach_function :rd_kafka_poll, [:pointer, :int], :void, blocking: true
-    attach_function :rd_kafka_outq_len, [:pointer], :int, blocking: true
+    attach_function :rd_kafka_poll, [:pointer, :int], :void
+    attach_function :rd_kafka_outq_len, [:pointer], :int
 
     # Metadata
 
@@ -185,8 +185,8 @@ module Rdkafka
     attach_function :rd_kafka_committed, [:pointer, :pointer, :int], :int
     attach_function :rd_kafka_commit, [:pointer, :pointer, :bool], :int, blocking: true
     attach_function :rd_kafka_poll_set_consumer, [:pointer], :void
-    attach_function :rd_kafka_consumer_poll, [:pointer, :int], :pointer, blocking: true
-    attach_function :rd_kafka_consumer_close, [:pointer], :void, blocking: true
+    attach_function :rd_kafka_consumer_poll, [:pointer, :int], :pointer
+    attach_function :rd_kafka_consumer_close, [:pointer], :void
     attach_function :rd_kafka_offset_store, [:pointer, :int32, :int64], :int
     attach_function :rd_kafka_pause_partitions, [:pointer, :pointer], :int
     attach_function :rd_kafka_resume_partitions, [:pointer, :pointer], :int


### PR DESCRIPTION
Poll and close may never be called at the same time. Remove the blocking flag in the bindings so the GIL will help us prevent this.