### PR TITLE
Check metadata cache for topic's partition count if available

### DIFF
--- a/lib/rdkafka/bindings.rb
+++ b/lib/rdkafka/bindings.rb
@@ -45,6 +45,7 @@ module Rdkafka
     attach_function :rd_kafka_clusterid, [:pointer], :string
     attach_function :rd_kafka_metadata, [:pointer, :int, :pointer, :pointer, :int], :int
     attach_function :rd_kafka_metadata_destroy, [:pointer], :void
+    attach_function :rd_kafka_metadata_cache_topic_get, [:pointer, :string, :int], :pointer
 
     # Message struct
 

--- a/lib/rdkafka/producer.rb
+++ b/lib/rdkafka/producer.rb
@@ -65,7 +65,11 @@ module Rdkafka
     # @return partition count [Integer,nil]
     def partition_count(topic)
       closed_producer_check(__method__)
-      Rdkafka::Metadata.new(@native_kafka.inner, topic).topics&.first[:partition_count]
+      if (topic_metadata = Rdkafka::Metadata.topic_metadata_from_cache(@native_kafka.inner, topic))
+        topic_metadata[:partition_count]
+      else
+        Rdkafka::Metadata.new(@native_kafka.inner, topic).topics&.first[:partition_count]
+      end
     end
 
     # Produces a message to a Kafka topic. The message is added to rdkafka's queue, call {DeliveryHandle#wait wait} on the returned delivery handle to make sure it is delivered.

--- a/spec/rdkafka/metadata_spec.rb
+++ b/spec/rdkafka/metadata_spec.rb
@@ -77,4 +77,39 @@ describe Rdkafka::Metadata do
       }.to raise_error(Rdkafka::RdkafkaError, /Local: Required feature not supported by broker \(unsupported_feature\)/)
     end
   end
+
+  describe "topic_metadata_from_cache" do
+    subject { described_class.topic_metadata_from_cache(native_kafka, topic_name) }
+    context "when metadata has been initialized" do
+      before do
+        described_class.new(native_kafka)
+      end
+
+      context "with a non-existing topic" do
+        let(:topic_name) { SecureRandom.uuid.to_s }
+
+        it "returns nil" do
+          expect(subject).to be_nil
+        end
+      end
+
+      context "with a topic that already exists" do
+        let(:topic_name) { "partitioner_test_topic" }
+
+        it "returns a hash of the topic metadata" do
+          expect(subject[:partition_count]).to eq(25)
+          expect(subject[:partitions].length).to eq(25)
+          expect(subject[:topic_name]).to eq(topic_name)
+        end
+      end
+    end
+
+    context "when metadata has not been initialized" do
+      let(:topic_name) { "partitioner_test_topic" }
+
+      it "returns nil, even for an existing topic" do
+        expect(subject).to be_nil
+      end
+    end
+  end
 end


### PR DESCRIPTION
### Problem
Currently when a message is produced without specifying a partition, a metadata request gets made to the kafka broker to get the number of partitions for the topic. That means every time we produce a message without specifying the partition, we have to make a request for the metadata. This is a lot of unnecessary requests happening to get a value (topic partition count) that changes _very_ infrequently, if ever.

### Solution
In this pull request, I have made changes to how the partition count for a topic is found, such that the we first search the metadata cache for the topic's partition count. If the topic exists in the metadata cache, then we use that partition count and do not make a request for metadata. If the topic doesn't exist in the metadata cache, then we make a request to the broker for the metadata (how it currently works).

Librdkafka source code: [rd_kafka_metadata_cache_topic_get](https://github.com/edenhill/librdkafka/blob/master/src/rdkafka_metadata_cache.c#L635).