### PR TITLE
Update CHANGELOG.md with metadata timeout configurable

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@
 * Fix potential race condition in multi-threaded producer (mensfeld)
 * Fix leaking FFI resources in specs (mensfeld)
 * Improve specs stability (mensfeld)
+* Make metadata request timeout configurable (mensfeld)
 
 # 0.12.0
 * Bumps librdkafka to 1.9.0


### PR DESCRIPTION
ref https://github.com/appsignal/rdkafka-ruby/pull/239

not pinging anyone as it's just a readme update.