### PR TITLE
Lock native only on closing and track usage

### DIFF
--- a/lib/rdkafka/consumer.rb
+++ b/lib/rdkafka/consumer.rb
@@ -27,9 +27,11 @@ module Rdkafka
     def close
       return if closed?
       ObjectSpace.undefine_finalizer(self)
-      @native_kafka.with_inner do |inner|
+
+      @native_kafka.synchronize do |inner|
         Rdkafka::Bindings.rd_kafka_consumer_close(inner)
       end
+
       @native_kafka.close
     end
 

--- a/lib/rdkafka/error.rb
+++ b/lib/rdkafka/error.rb
@@ -92,4 +92,10 @@ module Rdkafka
       super("Illegal call to #{method.to_s} on a closed admin")
     end
   end
+
+  class ClosedInnerError < BaseError
+    def initialize
+      super("Illegal call to a closed inner librdkafka instance")
+    end
+  end
 end

--- a/lib/rdkafka/native_kafka.rb
+++ b/lib/rdkafka/native_kafka.rb
@@ -10,6 +10,8 @@ module Rdkafka
       @access_mutex = Mutex.new
       # Lock around internal polling
       @poll_mutex = Mutex.new
+      # counter for operations in progress using inner
+      @operations_in_progress = 0
 
       if run_polling_thread
         # Start thread to poll client for delivery callbacks,
@@ -35,10 +37,26 @@ module Rdkafka
     end
 
     def with_inner
-      return if @inner.nil?
+      if @access_mutex.owned?
+        @operations_in_progress += 1
+      else
+        @access_mutex.synchronize { @operations_in_progress += 1 }
+      end
 
+      @inner.nil? ? raise(ClosedInnerError) : yield(@inner)
+    ensure
+      @operations_in_progress -= 1
+    end
+
+    def synchronize(&block)
       @access_mutex.synchronize do
-        yield @inner
+        # Wait for any commands using the inner to finish
+        # This can take a while on blocking operations like polling but is essential not to proceed
+        # with the destroy until all the outgoing operations are finished. Otherwise the process
+        # will either hand or crash
+        sleep(0.01) until @operations_in_progress.zero?
+
+        with_inner(&block)
       end
     end
 
@@ -53,31 +71,31 @@ module Rdkafka
     def close(object_id=nil)
       return if closed?
 
-      @access_mutex.lock
+      synchronize do
+        # Indicate to the outside world that we are closing
+        @closing = true
 
-      # Indicate to the outside world that we are closing
-      @closing = true
+        if @polling_thread
+          # Indicate to polling thread that we're closing
+          @polling_thread[:closing] = true
 
-      if @polling_thread
-        # Indicate to polling thread that we're closing
-        @polling_thread[:closing] = true
+          # Wait for the polling thread to finish up,
+          # this can be aborted in practice if this
+          # code runs from a finalizer.
+          @polling_thread.join
+        end
 
-        # Wait for the polling thread to finish up,
-        # this can be aborted in practice if this
-        # code runs from a finalizer.
-        @polling_thread.join
+        # Destroy the client after locking both mutexes
+        @poll_mutex.lock
+
+        # This check prevents a race condition, where we would enter the close in two threads
+        # and after unlocking the primary one that hold the lock but finished, ours would be unlocked
+        # and would continue to run, trying to destroy inner twice
+        return unless @inner
+
+        Rdkafka::Bindings.rd_kafka_destroy(@inner)
+        @inner = nil
       end
-
-      # Destroy the client after locking both mutexes
-      @poll_mutex.lock
-
-      # This check prevents a race condition, where we would enter the close in two threads
-      # and after unlocking the primary one that hold the lock but finished, ours would be unlocked
-      # and would continue to run, trying to destroy inner twice
-      return unless @inner
-
-      Rdkafka::Bindings.rd_kafka_destroy(@inner)
-      @inner = nil
     end
   end
 end

--- a/lib/rdkafka/native_kafka.rb
+++ b/lib/rdkafka/native_kafka.rb
@@ -52,8 +52,8 @@ module Rdkafka
       @access_mutex.synchronize do
         # Wait for any commands using the inner to finish
         # This can take a while on blocking operations like polling but is essential not to proceed
-        # with the destroy until all the outgoing operations are finished. Otherwise the process
-        # will either hand or crash
+        # with certain types of operations like resources destruction as it can cause the process
+        # to hang or crash
         sleep(0.01) until @operations_in_progress.zero?
 
         with_inner(&block)


### PR DESCRIPTION
This PR:

- intoduces a new native kafka method called `#synchronize` that yields only when no parallel requests are running (including started before the lock), ensuring that a given C binding operation can be started and finished fully without any other.
- all the other potential operations are blocked on the increment mutex
- no need to have mutexed decrement as the zero value reachability is anyhow guarded by sleep
- spec was added to ensure, that long polling is finished before close happens.

Thanks to this approach we ensure that both closing the native as well as any operations (like consumer shutdown) can operate only when no other operations are running (mainly poll that is long running) and that all the resources are cleaned prior.

Since we may have a potential race condition where the client is closed and cleaned but some requests are pilling up, there is a new error called `ClosedInnerError` to indicate this. It should only happen if someone is doing multi-threading without proper resources management, nonetheless much better than returning nil as it was previously done.

close https://github.com/appsignal/rdkafka-ruby/issues/260