### PR TITLE
Possible race condition in NativeKafka#close

### DIFF
--- a/lib/rdkafka/native_kafka.rb
+++ b/lib/rdkafka/native_kafka.rb
@@ -83,9 +83,9 @@ module Rdkafka
     end
 
     def close(object_id=nil)
-      return if closed?
-
       synchronize do
+        return if closed?
+
         # Indicate to the outside world that we are closing
         @closing = true
 


### PR DESCRIPTION
Since the check to closed? is not protected by the mutex, it's possible for two threads to return false for closed? and thus call rd_kafka_destroy twice.
