### PR TITLE
Allow stopping a consumer without closing it

### DIFF
--- a/spec/rdkafka/consumer_spec.rb
+++ b/spec/rdkafka/consumer_spec.rb
@@ -692,6 +692,32 @@ describe Rdkafka::Consumer do
     end
   end
 
+  describe "#stop" do
+    it "should stop polling with #each" do
+      consumer.subscribe("consume_test_topic")
+      # Check the first 10 messages. Then +stop+ the consumer, which
+      # should break the +each+ loop.
+      consumer.each do
+        consumer.stop
+      end
+      expect(consumer.stopped?).to eq(true)
+      expect(consumer.closed?).to eq(false)
+      consumer.close
+    end
+
+    it "should stop polling with #each_batch" do
+      consumer.subscribe("consume_test_topic")
+      # Check the first 10 messages. Then +stop+ the consumer, which
+      # should break the +each_batch+ loop.
+      consumer.each_batch do
+        consumer.stop
+      end
+      expect(consumer.stopped?).to eq(true)
+      expect(consumer.closed?).to eq(false)
+      consumer.close
+    end
+  end
+
   describe "#each" do
     it "should yield messages" do
       handles = []


### PR DESCRIPTION
Let's say we run consumer.each_batch and process messages asynchronously.  At some point the consumer terminates. 
I'd like to stop polling, wait until messages got processed, store offsets and commit. In other words gracefully shutting down. 
Until now, the only option I have to stop iterating is to close consumer. But in this case I can't do final commit.
Please let me know if I'm missing something. Thank you.